### PR TITLE
fix: tune Claude Action gate execution

### DIFF
--- a/.github/workflows/shiki-cca-completion.yml
+++ b/.github/workflows/shiki-cca-completion.yml
@@ -84,7 +84,8 @@ jobs:
           claude_args: |
             --append-system-prompt "You are Shiki CCA. Judge completion only. Do not edit production code. Non-complete verdicts must include precise next actions."
             --json-schema '${{ steps.schema.outputs.json }}'
-            --max-turns 5
+            --max-turns 15
+            --allowedTools "Read,Glob,Grep,Bash(git diff:*),Bash(git status:*),Bash(gh pr view:*),Bash(gh pr diff:*)"
 
       - name: Enforce CCA verdict
         env:

--- a/.github/workflows/shiki-claude-review.yml
+++ b/.github/workflows/shiki-claude-review.yml
@@ -48,4 +48,6 @@ jobs:
             4. Scope drift or unrelated cleanup.
 
             If there are no blocking findings, say that clearly and list any residual risk.
-          claude_args: "--max-turns 5"
+          claude_args: |
+            --max-turns 15
+            --allowedTools "Read,Glob,Grep,Bash(git diff:*),Bash(git status:*),Bash(gh pr view:*),Bash(gh pr diff:*)"


### PR DESCRIPTION
## Shiki Task

- Goal: G-0001
- Task: T-0003
- Issue: claude-action-tuning
- Runtime: Codex Front
- Risk: medium

## Scope

Tune Claude Code Action jobs so post-bootstrap CCA/review checks have enough read-only turns and explicit read-only tools.

## Non-Goals

- Do not change Shiki policy semantics.
- Do not bypass CCA after this bootstrap fix is merged.
- Do not expose secrets.

## Acceptance

- Workflow YAML parses locally.
- Shiki validation passes locally.
- Claude Code Action gets `--max-turns 15`.
- Claude Code Action read-only tools are explicitly allowed for PR inspection.
- Required CCA/MergeGate checks are restored after this bootstrap workflow fix lands.

## Evidence

- Local validation: `python3 scripts/validate_shiki.py`
- Local YAML parse: `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f) }" .github/workflows/shiki-claude-review.yml .github/workflows/shiki-cca-completion.yml`
- Reason: previous smoke run authenticated successfully, then failed at `Reached maximum number of turns (5)`.

## MergeGate

- Dependencies: PR #6 smoke test revealed the workflow tuning issue.
- Locks: `.github/workflows/shiki-claude-review.yml`, `.github/workflows/shiki-cca-completion.yml`
- Risk: medium because workflow files changed.
- Guardian approval: repository admin controlled bootstrap exception required.
