### PR TITLE
fix: request structured CCA output

### DIFF
--- a/.github/workflows/shiki-cca-completion.yml
+++ b/.github/workflows/shiki-cca-completion.yml
@@ -83,6 +83,7 @@ jobs:
             Return structured JSON matching .shiki/schemas/cca-verdict.schema.json.
           claude_args: |
             --append-system-prompt "You are Shiki CCA. Judge completion only. Do not edit production code. Non-complete verdicts must include precise next actions."
+            --output-format json
             --json-schema '${{ steps.schema.outputs.json }}'
             --max-turns 15
             --allowedTools "Read,Glob,Grep,Bash(git diff:*),Bash(git status:*),Bash(gh pr view:*),Bash(gh pr diff:*)"


### PR DESCRIPTION
## Shiki Task

- Goal: G-0001
- Task: T-0004
- Issue: cca-structured-output
- Runtime: Codex Front
- Risk: medium

## Scope

Fix CCA workflow structured output by passing `--output-format json` together with `--json-schema`.

## Non-Goals

- Do not change CCA policy semantics.
- Do not expose secrets.
- Do not bypass CCA after this bootstrap workflow fix lands.

## Acceptance

- Shiki validation passes locally.
- Workflow YAML parses locally.
- CCA uses Claude Code's documented structured output invocation: `--output-format json` with `--json-schema`.
- Required CCA/MergeGate checks are restored after this workflow fix lands.

## Evidence

- Local validation: `python3 scripts/validate_shiki.py`
- Local YAML parse: `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f) }" .github/workflows/shiki-cca-completion.yml`
- Previous smoke evidence: CCA reached Claude successfully but failed because `--json-schema was provided but Claude did not return structured_output`.
- Official reference: https://code.claude.com/docs/en/headless

## MergeGate

- Dependencies: PR #6 smoke test revealed missing structured output configuration.
- Locks: `.github/workflows/shiki-cca-completion.yml`
- Risk: medium because workflow files changed.
- Guardian approval: repository admin controlled bootstrap exception required.
