### PR TITLE
fix: simplify CCA structured schema

### DIFF
--- a/.github/workflows/shiki-cca-completion.yml
+++ b/.github/workflows/shiki-cca-completion.yml
@@ -83,7 +83,6 @@ jobs:
             Return structured JSON matching .shiki/schemas/cca-verdict.schema.json.
           claude_args: |
             --append-system-prompt "You are Shiki CCA. Judge completion only. Do not edit production code. Non-complete verdicts must include precise next actions."
-            --output-format json
             --json-schema '${{ steps.schema.outputs.json }}'
             --max-turns 15
             --allowedTools "Read,Glob,Grep,Bash(git diff:*),Bash(git status:*),Bash(gh pr view:*),Bash(gh pr diff:*)"

--- a/.shiki/schemas/cca-verdict.schema.json
+++ b/.shiki/schemas/cca-verdict.schema.json
@@ -1,7 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://shiki.local/schemas/cca-verdict.schema.json",
-  "title": "Shiki CCA Verdict",
   "type": "object",
   "required": [
     "verdict",
@@ -11,10 +8,6 @@
     "pr",
     "head_sha",
     "can_merge",
-    "checklist",
-    "acceptance",
-    "mergegate",
-    "repair_packet",
     "confidence"
   ],
   "properties": {
@@ -27,68 +20,14 @@
         "insufficient_evidence"
       ]
     },
-    "summary": { "type": "string", "minLength": 1 },
-    "goal_id": { "type": "string", "pattern": "^G-[0-9]{4,}$" },
-    "task_id": { "type": "string", "pattern": "^T-[0-9]{4,}$" },
-    "pr": { "type": "integer", "minimum": 1 },
-    "head_sha": { "type": "string", "minLength": 7 },
+    "summary": { "type": "string" },
+    "goal_id": { "type": "string" },
+    "task_id": { "type": "string" },
+    "pr": { "type": "integer" },
+    "head_sha": { "type": "string" },
     "can_merge": { "type": "boolean" },
-    "checklist": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["id", "status", "blocking", "evidence", "reason"],
-        "properties": {
-          "id": { "type": "string", "minLength": 1 },
-          "status": {
-            "enum": ["pass", "fail", "insufficient_evidence", "not_applicable"]
-          },
-          "blocking": { "type": "boolean" },
-          "evidence": { "type": "string" },
-          "reason": { "type": "string" }
-        },
-        "additionalProperties": true
-      }
-    },
-    "acceptance": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["criterion", "status", "evidence"],
-        "properties": {
-          "criterion": { "type": "string", "minLength": 1 },
-          "status": {
-            "enum": ["pass", "fail", "insufficient_evidence", "not_applicable"]
-          },
-          "evidence": { "type": "string" }
-        },
-        "additionalProperties": true
-      }
-    },
-    "mergegate": {
-      "type": "object",
-      "required": [
-        "dependencies",
-        "locks",
-        "checks",
-        "review",
-        "ledger",
-        "risk"
-      ],
-      "properties": {
-        "dependencies": { "type": "string" },
-        "locks": { "type": "string" },
-        "checks": { "type": "string" },
-        "review": { "type": "string" },
-        "ledger": { "type": "string" },
-        "risk": { "type": "string" }
-      },
-      "additionalProperties": true
-    },
-    "repair_packet": {
-      "type": ["object", "null"]
-    },
-    "confidence": { "type": "number", "minimum": 0, "maximum": 1 }
-  },
-  "additionalProperties": true
+    "blocking_reason": { "type": "string" },
+    "repair_packet": { "type": "string" },
+    "confidence": { "type": "number" }
+  }
 }


### PR DESCRIPTION
## Shiki Task

- Goal: G-0001
- Task: T-0005
- Issue: cca-schema-simplify
- Runtime: Codex Front
- Risk: medium

## Scope

Align the CCA structured output workflow with Claude Code Action v1 usage by using `--json-schema` only and simplifying the CCA verdict schema to a flat machine gate contract.

## Non-Goals

- Do not change MergeGate enforcement semantics.
- Do not expose secrets.
- Do not bypass CCA after this bootstrap workflow/schema fix lands.

## Acceptance

- Shiki validation passes locally.
- Workflow YAML parses locally.
- CCA verdict schema is valid JSON.
- CCA workflow no longer passes `--output-format json` to Claude Code Action.
- Required CCA/MergeGate checks are restored after this workflow/schema fix lands.

## Evidence

- Local validation: `python3 scripts/validate_shiki.py`
- Local YAML parse: `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f) }" .github/workflows/shiki-cca-completion.yml`
- Local JSON parse: `python3 -m json.tool .shiki/schemas/cca-verdict.schema.json`
- Official Action reference: https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md#structured-outputs

## MergeGate

- Dependencies: PR #6 smoke test showed the CCA action did not produce a usable structured output with the previous schema/configuration.
- Locks: `.github/workflows/shiki-cca-completion.yml`, `.shiki/schemas/cca-verdict.schema.json`
- Risk: medium because workflow and schema files changed.
- Guardian approval: repository admin controlled bootstrap exception required.
