### PR TITLE
feat: install Shiki globally as CLI and slash command

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -1,0 +1,43 @@
+---
+description: Run the Shiki GitHub-first agentic engineering control plane.
+argument-hint: "[goal, task, repo path, or Shiki CLI subcommand]"
+allowed-tools: Bash(shiki:*), Bash(git status:*), Bash(git branch:*), Bash(git diff:*), Bash(gh pr view:*), Bash(gh pr checks:*), Read, Glob, Grep
+---
+
+# Shiki
+
+Use Shiki as the GitHub-first control plane for Goal Seek, Context and Impact,
+Task DAG, Codex implementation handoff, CCA completion judgment, MergeGate, and
+bounded repair loops.
+
+## First Action
+
+Run:
+
+```bash
+shiki status
+```
+
+If the current repository does not have Shiki installed and the user asked to
+set up the repository, run:
+
+```bash
+shiki install-target .
+```
+
+## Operating Rules
+
+- Treat Codex as implementer, CCA as completion judge, and MergeGate as merge authorization.
+- For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.
+- Do not claim completion from local work alone. Completion requires PR evidence, CCA, and MergeGate.
+- Do not bypass branch protection. Do not use admin merge.
+- For workflow changes that cannot pass CCA until merged, require explicit Guardian approval before any temporary protection exception.
+
+## User Input
+
+Use the command arguments as the goal or task prompt:
+
+```text
+$ARGUMENTS
+```
+

--- a/.codex/skills/shiki/SKILL.md
+++ b/.codex/skills/shiki/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: shiki
+description: Use when the user invokes Shiki, /shiki, or asks to run the GitHub-first agentic engineering control plane for Goal Seek, Context and Impact, Task DAG, Codex implementation, CCA completion judgment, MergeGate, or bounded repair loops.
+---
+
+# Shiki
+
+Shiki is the user's GitHub-first, runtime-agnostic control plane for agentic
+engineering.
+
+## Start
+
+Run:
+
+```bash
+shiki status
+```
+
+Then inspect the target repository's `AGENTS.md`, `CLAUDE.md`, `CONTEXT.md`,
+`.shiki/`, `docs/agents/`, and open PR/issue state before changing files.
+
+## Responsibilities
+
+- Codex implements and repairs.
+- Claude Code Action can act as GitHub-side CCA or reviewer.
+- CCA judges completion.
+- MergeGate authorizes state transitions and merge readiness.
+- GitHub branch protection is the hard gate.
+
+## Rules
+
+- For non-trivial goals, enter through `grill-with-docs`.
+- Use Context and Impact before implementation.
+- Keep tasks as vertical slices with explicit locks and verification.
+- Use TDD for implementation work when behavior changes.
+- Do not call implementation complete until GitHub evidence, CCA, and MergeGate support it.
+- Do not bypass branch protection or use admin merge.
+- If a workflow change needs a bootstrap exception, ask for explicit Guardian approval first.
+
+## Commands
+
+- `shiki install-global`
+- `shiki install-target /path/to/repo`
+- `shiki bootstrap-github --repo OWNER/REPO`
+- `shiki status`
+

--- a/.shiki/ledger/L-0005.json
+++ b/.shiki/ledger/L-0005.json
@@ -1,0 +1,18 @@
+{
+  "id": "L-0005",
+  "timestamp": "2026-05-28T05:45:00Z",
+  "goal_id": "G-0001",
+  "task_id": "T-0005",
+  "type": "check",
+  "actor": "codex",
+  "summary": "Added global Shiki installation support, Claude /shiki command, Codex Shiki skill, and aligned branch protection defaults with the verified gate.",
+  "evidence": [
+    "path:scripts/shiki.py",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "skill:tdd",
+    "command:shiki install-target /private/tmp/shiki-install-target-smoke"
+  ],
+  "links": []
+}

--- a/.shiki/tasks/T-0005.json
+++ b/.shiki/tasks/T-0005.json
@@ -1,0 +1,40 @@
+{
+  "id": "T-0005",
+  "goal_id": "G-0001",
+  "github_issue": null,
+  "title": "Install Shiki as a global CLI and slash command",
+  "scope": "Make Shiki callable from any repository through the global CLI, Claude Code /shiki command, and Codex global skill while aligning bootstrap branch protection with the verified production gate.",
+  "non_goals": [
+    "Do not bypass branch protection.",
+    "Do not change CCA or MergeGate workflow behavior.",
+    "Do not require target repositories to install dependencies before Shiki can run."
+  ],
+  "dependencies": [],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:.shiki/tasks/T-0005.json",
+    "path:.shiki/ledger/L-0005.json"
+  ],
+  "assigned_runtime": "codex-front",
+  "risk_level": "low",
+  "required_skills": [
+    "tdd"
+  ],
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py",
+    "python3 scripts/shiki.py --help lists install-global.",
+    "python3 scripts/shiki.py status reports global command and integration paths.",
+    "python3 scripts/shiki.py install-global installs CLI, Claude command, and Codex skill.",
+    "python3 scripts/shiki.py install-target installs command integrations without copying platform task or ledger state.",
+    "Branch protection payload defaults to the verified Shiki gate values."
+  ],
+  "expected_branch": "shiki-global-command-and-slash",
+  "expected_pr": null,
+  "ledger_evidence": [
+    "L-0005"
+  ],
+  "status": "review"
+}

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -2,13 +2,20 @@
 
 `bin/shiki` is the single operational entrypoint for repeatable Shiki setup.
 
-## Install The Command Once
+## Install Globally Once
 
 ```bash
-/Users/kio.mizutani/shiki/bin/shiki install-command
+/Users/kio.mizutani/shiki/bin/shiki install-global
 ```
 
-This creates `~/.local/bin/shiki`. Ensure `~/.local/bin` is on `PATH`.
+This creates or updates:
+
+- `~/.local/bin/shiki`
+- `~/.claude/commands/shiki.md`
+- `~/.codex/skills/shiki/SKILL.md`
+
+Ensure `~/.local/bin` is on `PATH`. Restart Codex or Claude Code if the
+running client does not reload commands dynamically.
 
 ## Publish This Shiki Repo
 
@@ -40,6 +47,21 @@ shiki install-target /path/to/target-repo
 ```
 
 Use `--force` only when you intentionally want to overwrite existing target files.
+
+## Slash Command
+
+After `shiki install-global`, Claude Code can invoke:
+
+```text
+/shiki <goal or task>
+```
+
+Codex can use the global `shiki` skill in future sessions and can always call
+the CLI directly:
+
+```bash
+shiki status
+```
 
 ## Required GitHub Checks
 

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -27,6 +27,8 @@ TEMPLATE_PATHS = [
     "CLAUDE.md",
     "CONTEXT.md",
     "SYSTEM_PROMPT.md",
+    ".claude/commands/shiki.md",
+    ".codex/skills/shiki/SKILL.md",
     ".shiki",
     ".github/ISSUE_TEMPLATE",
     ".github/PULL_REQUEST_TEMPLATE",
@@ -47,6 +49,17 @@ DEFAULT_REQUIRED_CHECKS = [
     "Validate Shiki mirror",
     "CCA verdict",
     "MergeGate policy check",
+]
+
+DEFAULT_GLOBAL_COMMAND_PATH = "~/.local/bin/shiki"
+DEFAULT_CLAUDE_COMMAND_PATH = "~/.claude/commands/shiki.md"
+DEFAULT_CODEX_SKILL_PATH = "~/.codex/skills/shiki/SKILL.md"
+TARGET_STATE_DIRECTORIES = [
+    ".shiki/goals",
+    ".shiki/tasks",
+    ".shiki/ledger",
+    ".shiki/locks",
+    ".shiki/worktrees",
 ]
 
 
@@ -192,14 +205,15 @@ def protect_branch(repo: str, branch: str, required_checks: list[str]) -> None:
             "strict": True,
             "contexts": required_checks,
         },
-        "enforce_admins": False,
+        "enforce_admins": True,
         "required_pull_request_reviews": {
             "dismiss_stale_reviews": True,
             "require_code_owner_reviews": False,
-            "required_approving_review_count": 1,
+            "required_approving_review_count": 0,
         },
         "restrictions": None,
-        "required_linear_history": True,
+        "required_conversation_resolution": True,
+        "required_linear_history": False,
         "allow_force_pushes": False,
         "allow_deletions": False,
     }
@@ -289,17 +303,24 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
     return 0
 
 
-def should_skip(path: Path) -> bool:
+def should_skip(path: Path, *, target_install: bool = False) -> bool:
     parts = set(path.parts)
-    return "__pycache__" in parts or path.name == ".DS_Store" or path.suffix == ".pyc"
+    if "__pycache__" in parts or path.name == ".DS_Store" or path.suffix == ".pyc":
+        return True
+    if target_install:
+        relative = path.relative_to(ROOT)
+        relative_text = relative.as_posix()
+        state_prefixes = tuple(f"{directory}/" for directory in TARGET_STATE_DIRECTORIES)
+        return relative_text.startswith(state_prefixes)
+    return False
 
 
-def copy_path(source: Path, target: Path, *, force: bool) -> None:
-    if should_skip(source):
+def copy_path(source: Path, target: Path, *, force: bool, target_install: bool = False) -> None:
+    if should_skip(source, target_install=target_install):
         return
     if source.is_dir():
         for child in source.iterdir():
-            copy_path(child, target / child.name, force=force)
+            copy_path(child, target / child.name, force=force, target_install=target_install)
         return
 
     if target.exists() and not force:
@@ -323,7 +344,12 @@ def cmd_install_target(args: argparse.Namespace) -> int:
         if not source.exists():
             warn(f"template path missing, skipped: {relative}")
             continue
-        copy_path(source, target / relative, force=args.force)
+        copy_path(source, target / relative, force=args.force, target_install=True)
+
+    for relative in TARGET_STATE_DIRECTORIES:
+        state_dir = target / relative
+        state_dir.mkdir(parents=True, exist_ok=True)
+        info(f"ensured empty state directory: {state_dir}")
 
     if args.validate:
         run(["python3", "scripts/validate_shiki.py"], cwd=target)
@@ -333,19 +359,60 @@ def cmd_install_target(args: argparse.Namespace) -> int:
 
 
 def cmd_install_command(args: argparse.Namespace) -> int:
-    destination = Path(args.path).expanduser().resolve()
+    destination = Path(args.path).expanduser()
+    install_cli_command(destination)
+    info("ensure the parent directory is on PATH")
+    return 0
+
+
+def install_cli_command(destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     if destination.exists() or destination.is_symlink():
         destination.unlink()
     destination.symlink_to(ROOT / "bin" / "shiki")
     info(f"installed command: {destination}")
-    info("ensure the parent directory is on PATH")
+
+
+def install_file(source: Path, destination: Path) -> None:
+    if not source.exists():
+        raise ShikiError(f"source file not found: {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    info(f"installed {destination}")
+
+
+def cmd_install_global(args: argparse.Namespace) -> int:
+    install_cli_command(Path(args.path).expanduser())
+
+    if args.claude_command:
+        install_file(
+            ROOT / ".claude" / "commands" / "shiki.md",
+            Path(args.claude_command_path).expanduser(),
+        )
+
+    if args.codex_skill:
+        install_file(
+            ROOT / ".codex" / "skills" / "shiki" / "SKILL.md",
+            Path(args.codex_skill_path).expanduser(),
+        )
+
+    info("global install complete")
+    info("restart Codex or Claude Code if the running client does not reload commands dynamically")
     return 0
 
 
 def cmd_status(_: argparse.Namespace) -> int:
     config = load_default_config()
-    print(json.dumps({"root": str(ROOT), "config": config}, indent=2, sort_keys=True))
+    status = {
+        "root": str(ROOT),
+        "config": config,
+        "command": shutil.which("shiki"),
+        "claude_command": str(Path(DEFAULT_CLAUDE_COMMAND_PATH).expanduser()),
+        "claude_command_installed": Path(DEFAULT_CLAUDE_COMMAND_PATH).expanduser().exists(),
+        "codex_skill": str(Path(DEFAULT_CODEX_SKILL_PATH).expanduser()),
+        "codex_skill_installed": Path(DEFAULT_CODEX_SKILL_PATH).expanduser().exists(),
+    }
+    print(json.dumps(status, indent=2, sort_keys=True))
     return 0
 
 
@@ -374,8 +441,16 @@ def build_parser() -> argparse.ArgumentParser:
     target.set_defaults(func=cmd_install_target)
 
     install = subcommands.add_parser("install-command", help="Install a shiki command symlink")
-    install.add_argument("--path", default="~/.local/bin/shiki")
+    install.add_argument("--path", default=DEFAULT_GLOBAL_COMMAND_PATH)
     install.set_defaults(func=cmd_install_command)
+
+    global_install = subcommands.add_parser("install-global", help="Install global Shiki CLI, Claude slash command, and Codex skill")
+    global_install.add_argument("--path", default=DEFAULT_GLOBAL_COMMAND_PATH)
+    global_install.add_argument("--claude-command", action=argparse.BooleanOptionalAction, default=True)
+    global_install.add_argument("--claude-command-path", default=DEFAULT_CLAUDE_COMMAND_PATH)
+    global_install.add_argument("--codex-skill", action=argparse.BooleanOptionalAction, default=True)
+    global_install.add_argument("--codex-skill-path", default=DEFAULT_CODEX_SKILL_PATH)
+    global_install.set_defaults(func=cmd_install_global)
 
     status = subcommands.add_parser("status", help="Show local Shiki CLI configuration")
     status.set_defaults(func=cmd_status)


### PR DESCRIPTION
## Shiki Task

- Goal: G-0001
- Task: T-0005
- Runtime: Codex Front
- Risk: low
- CCA checklist profile: PR, V, CCA, MG

## Scope

Make Shiki callable from anywhere through:

- global `shiki` CLI
- Claude Code `/shiki` command
- Codex global Shiki skill
- target repo template installation

Also align `bootstrap-github --protect` with the verified production branch protection gate.

## Acceptance

- `python3 scripts/validate_shiki.py` passes.
- `python3 -m py_compile scripts/shiki.py` passes.
- `shiki status` works outside the Shiki repo.
- `shiki --help` works from `/private/tmp`.
- `shiki install-global` installs CLI, Claude command, and Codex skill.
- `shiki install-target` installs command integrations without copying platform task or ledger state.
- Branch protection payload defaults match the verified gate:
  - `Validate Shiki mirror`
  - `CCA verdict`
  - `MergeGate policy check`
  - `strict: true`
  - `enforce_admins: true`
  - approving reviews: `0`

## Evidence

- Local validation: `python3 scripts/validate_shiki.py`
- Python compile: `python3 -m py_compile scripts/shiki.py`
- Global install: `python3 scripts/shiki.py install-global`
- Global status from `/Users/kio.mizutani`: `shiki status`
- CLI help from `/private/tmp`: `shiki --help`
- Target smoke: `shiki install-target /private/tmp/shiki-install-target-smoke-2`
- Target smoke verified `.claude/commands/shiki.md`, `.codex/skills/shiki/SKILL.md`, empty `.shiki/tasks`, empty `.shiki/ledger`, and `scripts/validate_shiki.py`

## MergeGate

- Dependencies: PR #6 smoke gate, PR #10 CCA non-recursive rules, PR #11 CCA/MergeGate separation
- Locks: `scripts/shiki.py`, `.claude/commands/shiki.md`, `.codex/skills/shiki/SKILL.md`, `docs/agents/bootstrap-command.md`, `.shiki/tasks/T-0005.json`, `.shiki/ledger/L-0005.json`
- Risk: low; CLI/template/docs only
- Guardian approval: not required
