### PR TITLE
fix: enforce GitHub-first target initialization

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -19,10 +19,11 @@ shiki status
 ```
 
 If the current repository does not have Shiki installed and the user asked to
-set up the repository, run:
+set up the repository, do not run a local-only install. Ask for the GitHub repo
+slug if it is not provided, then run:
 
 ```bash
-shiki install-target .
+shiki init . --repo OWNER/NAME
 ```
 
 ## Operating Rules
@@ -30,6 +31,7 @@ shiki install-target .
 - Treat Codex as implementer, CCA as completion judge, and MergeGate as merge authorization.
 - For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.
 - Do not claim completion from local work alone. Completion requires PR evidence, CCA, and MergeGate.
+- Do not use `shiki install-target` unless the user explicitly asks for a local-only template copy.
 - Do not bypass branch protection. Do not use admin merge.
 - For workflow changes that cannot pass CCA until merged, require explicit Guardian approval before any temporary protection exception.
 
@@ -40,4 +42,3 @@ Use the command arguments as the goal or task prompt:
 ```text
 $ARGUMENTS
 ```
-

--- a/.codex/skills/shiki/SKILL.md
+++ b/.codex/skills/shiki/SKILL.md
@@ -19,6 +19,14 @@ shiki status
 Then inspect the target repository's `AGENTS.md`, `CLAUDE.md`, `CONTEXT.md`,
 `.shiki/`, `docs/agents/`, and open PR/issue state before changing files.
 
+If Shiki is not installed in the target repository, do not use a local-only
+template install by default. Ask for the GitHub repository slug if it is
+missing, then run:
+
+```bash
+shiki init . --repo OWNER/NAME
+```
+
 ## Responsibilities
 
 - Codex implements and repairs.
@@ -34,13 +42,13 @@ Then inspect the target repository's `AGENTS.md`, `CLAUDE.md`, `CONTEXT.md`,
 - Keep tasks as vertical slices with explicit locks and verification.
 - Use TDD for implementation work when behavior changes.
 - Do not call implementation complete until GitHub evidence, CCA, and MergeGate support it.
+- Do not use `shiki install-target` unless the user explicitly asks for local-only template copying.
 - Do not bypass branch protection or use admin merge.
 - If a workflow change needs a bootstrap exception, ask for explicit Guardian approval first.
 
 ## Commands
 
 - `shiki install-global`
-- `shiki install-target /path/to/repo`
-- `shiki bootstrap-github --repo OWNER/REPO`
+- `shiki init /path/to/repo --repo OWNER/REPO`
+- `shiki preflight --require-github`
 - `shiki status`
-

--- a/.shiki/ledger/L-0006.json
+++ b/.shiki/ledger/L-0006.json
@@ -1,0 +1,22 @@
+{
+  "id": "L-0006",
+  "timestamp": "2026-05-28T07:45:00Z",
+  "goal_id": "G-0001",
+  "task_id": "T-0006",
+  "type": "check",
+  "actor": "codex",
+  "summary": "Changed Shiki target setup so GitHub-first initialization uses shiki init --repo, while install-target requires explicit local-only intent.",
+  "evidence": [
+    "path:scripts/shiki.py",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "skill:diagnose",
+    "skill:tdd",
+    "command:python3 scripts/shiki.py init /private/tmp/shiki-init-missing-repo => exits non-zero without --repo",
+    "command:python3 scripts/shiki.py install-target /private/tmp/shiki-install-no-local => exits non-zero without --local-only",
+    "command:python3 scripts/shiki.py install-target /private/tmp/shiki-local-only-smoke --local-only => validates local-only template copy",
+    "command:python3 scripts/shiki.py preflight /private/tmp/shiki-local-only-smoke --require-github => exits non-zero"
+  ],
+  "links": []
+}

--- a/.shiki/ledger/L-0006.json
+++ b/.shiki/ledger/L-0006.json
@@ -11,12 +11,15 @@
     "path:.claude/commands/shiki.md",
     "path:.codex/skills/shiki/SKILL.md",
     "path:docs/agents/bootstrap-command.md",
+    "path:scripts/test_shiki_init.sh",
     "skill:diagnose",
     "skill:tdd",
+    "command:git show HEAD:.claude/commands/shiki.md | grep 'shiki init . --repo OWNER/NAME' verifies committed slash command content even when Claude Action restores .claude from main",
     "command:python3 scripts/shiki.py init /private/tmp/shiki-init-missing-repo => exits non-zero without --repo",
     "command:python3 scripts/shiki.py install-target /private/tmp/shiki-install-no-local => exits non-zero without --local-only",
     "command:python3 scripts/shiki.py install-target /private/tmp/shiki-local-only-smoke --local-only => validates local-only template copy",
-    "command:python3 scripts/shiki.py preflight /private/tmp/shiki-local-only-smoke --require-github => exits non-zero"
+    "command:python3 scripts/shiki.py preflight /private/tmp/shiki-local-only-smoke --require-github => exits non-zero",
+    "command:bash scripts/test_shiki_init.sh => shiki init tests passed"
   ],
   "links": []
 }

--- a/.shiki/tasks/T-0006.json
+++ b/.shiki/tasks/T-0006.json
@@ -1,0 +1,41 @@
+{
+  "id": "T-0006",
+  "goal_id": "G-0001",
+  "github_issue": null,
+  "title": "Enforce GitHub-first Shiki target initialization",
+  "scope": "Make GitHub repository initialization the mandatory Shiki setup path for target repositories and demote local template copying to an explicit local-only operation.",
+  "non_goals": [
+    "Do not remove platform bootstrap compatibility.",
+    "Do not bypass branch protection.",
+    "Do not create real GitHub repositories in local tests."
+  ],
+  "dependencies": [],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:.shiki/tasks/T-0006.json",
+    "path:.shiki/ledger/L-0006.json"
+  ],
+  "assigned_runtime": "codex-front",
+  "risk_level": "medium",
+  "required_skills": [
+    "diagnose",
+    "tdd"
+  ],
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py",
+    "python3 -m py_compile scripts/shiki.py",
+    "python3 scripts/shiki.py --help lists init and preflight.",
+    "python3 scripts/shiki.py init /tmp/path without --repo exits non-zero.",
+    "python3 scripts/shiki.py install-target /tmp/path without --local-only exits non-zero.",
+    "python3 scripts/shiki.py install-target /tmp/path --local-only validates template copy."
+  ],
+  "expected_branch": "shiki-enforce-github-first-init",
+  "expected_pr": null,
+  "ledger_evidence": [
+    "L-0006"
+  ],
+  "status": "review"
+}

--- a/.shiki/tasks/T-0006.json
+++ b/.shiki/tasks/T-0006.json
@@ -15,6 +15,7 @@
     "path:.claude/commands/shiki.md",
     "path:.codex/skills/shiki/SKILL.md",
     "path:docs/agents/bootstrap-command.md",
+    "path:scripts/test_shiki_init.sh",
     "path:.shiki/tasks/T-0006.json",
     "path:.shiki/ledger/L-0006.json"
   ],
@@ -30,7 +31,8 @@
     "python3 scripts/shiki.py --help lists init and preflight.",
     "python3 scripts/shiki.py init /tmp/path without --repo exits non-zero.",
     "python3 scripts/shiki.py install-target /tmp/path without --local-only exits non-zero.",
-    "python3 scripts/shiki.py install-target /tmp/path --local-only validates template copy."
+    "python3 scripts/shiki.py install-target /tmp/path --local-only validates template copy.",
+    "bash scripts/test_shiki_init.sh passes and verifies committed .claude command content with git show."
   ],
   "expected_branch": "shiki-enforce-github-first-init",
   "expected_pr": null,

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -17,10 +17,29 @@ This creates or updates:
 Ensure `~/.local/bin` is on `PATH`. Restart Codex or Claude Code if the
 running client does not reload commands dynamically.
 
-## Publish This Shiki Repo
+## Initialize A Target Repository
 
 ```bash
-CLAUDE_CODE_OAUTH_TOKEN=... shiki bootstrap-github --repo OWNER/shiki --private
+shiki init /path/to/target-repo --repo OWNER/REPO --private
+```
+
+This is the standard Shiki entrypoint. It will:
+
+- install Shiki template files;
+- initialize Git if needed;
+- create the GitHub repository if missing;
+- add or update `origin`;
+- write `.shiki/repo.json`;
+- commit and push the initial Shiki state;
+- set `CLAUDE_CODE_OAUTH_TOKEN` from the environment when present;
+- configure branch protection with Shiki required checks when GitHub permissions allow it.
+
+Do not use `install-target` for normal setup. Shiki is GitHub-first.
+
+## Publish This Shiki Platform Repo
+
+```bash
+CLAUDE_CODE_OAUTH_TOKEN=... shiki bootstrap-platform --repo OWNER/shiki --private
 ```
 
 The command is idempotent. It will:
@@ -37,15 +56,16 @@ The command is idempotent. It will:
 After defaults are saved, rerun:
 
 ```bash
-shiki bootstrap-github
+shiki bootstrap-platform
 ```
 
-## Install Shiki Into A Target Repository
+## Local-Only Template Copy
 
 ```bash
-shiki install-target /path/to/target-repo
+shiki install-target /path/to/target-repo --local-only
 ```
 
+Use this only for tests, fixtures, or explicit local-only template inspection.
 Use `--force` only when you intentionally want to overwrite existing target files.
 
 ## Slash Command

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -61,6 +62,7 @@ TARGET_STATE_DIRECTORIES = [
     ".shiki/locks",
     ".shiki/worktrees",
 ]
+GITHUB_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
 @dataclass
@@ -143,6 +145,11 @@ def ensure_remote(repo: str, path: Path) -> None:
         return
     run(["git", "remote", "add", "origin", remote_url], cwd=path)
     info(f"added origin {remote_url}")
+
+
+def require_github_repo_slug(repo: str) -> None:
+    if not GITHUB_REPO.match(repo):
+        raise ShikiError("repo must be a GitHub slug like OWNER/NAME")
 
 
 def github_repo_exists(repo: str) -> bool:
@@ -242,6 +249,11 @@ def validate_local_shiki() -> None:
     info("local Shiki validation passed")
 
 
+def validate_target_shiki(target: Path) -> None:
+    run(["python3", "scripts/validate_shiki.py"], cwd=target)
+    info("target Shiki validation passed")
+
+
 def save_default_config(repo: str, branch: str) -> None:
     LOCAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
     data = {
@@ -267,6 +279,7 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
     repo = args.repo or config.get("repo")
     if not repo:
         raise ShikiError("missing --repo OWNER/NAME and no default repo configured")
+    require_github_repo_slug(repo)
 
     branch = args.branch or config.get("default_branch") or "main"
     visibility = "private" if args.private else "public"
@@ -301,6 +314,116 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
     save_default_config(repo, branch)
     info("bootstrap complete")
     return 0
+
+
+def write_target_repo_config(target: Path, repo: str, branch: str) -> None:
+    payload = {
+        "source_of_truth": "github",
+        "repo": repo,
+        "default_branch": branch,
+        "mirror": ".shiki",
+    }
+    path = target / ".shiki" / "repo.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    info(f"wrote target GitHub config: {path}")
+
+
+def install_template(target: Path, *, force: bool, validate: bool) -> None:
+    for relative in TEMPLATE_PATHS:
+        source = ROOT / relative
+        if not source.exists():
+            warn(f"template path missing, skipped: {relative}")
+            continue
+        copy_path(source, target / relative, force=force, target_install=True)
+
+    for relative in TARGET_STATE_DIRECTORIES:
+        state_dir = target / relative
+        state_dir.mkdir(parents=True, exist_ok=True)
+        info(f"ensured empty state directory: {state_dir}")
+
+    if validate:
+        validate_target_shiki(target)
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    require_tool("git")
+    require_tool("gh")
+
+    target = Path(args.target).expanduser().resolve()
+    target.mkdir(parents=True, exist_ok=True)
+
+    if not args.repo:
+        raise ShikiError("shiki init requires --repo OWNER/NAME because Shiki is GitHub-first")
+    repo = args.repo
+    require_github_repo_slug(repo)
+
+    branch = args.branch
+    visibility = "private" if args.private else "public"
+
+    run(["gh", "auth", "status"])
+    install_template(target, force=args.force, validate=args.validate)
+    write_target_repo_config(target, repo, branch)
+    ensure_git_repo(target, branch)
+    ensure_github_repo(repo, visibility)
+    ensure_remote(repo, target)
+
+    active_branch = current_branch(target)
+    if active_branch != branch:
+        run(["git", "checkout", "-B", branch], cwd=target)
+
+    if args.commit:
+        commit_all(target, args.commit_message)
+
+    if args.push:
+        push_branch(target, branch)
+        set_default_branch(repo, branch)
+
+    secret_value = os.environ.get(args.secret_env, "")
+    if args.set_secret:
+        if not secret_value:
+            warn(f"{args.secret_env} is not set; skipping GitHub secret")
+        else:
+            set_secret(repo, "CLAUDE_CODE_OAUTH_TOKEN", secret_value)
+
+    if args.protect:
+        protect_branch(repo, branch, args.required_check)
+
+    info("GitHub-first init complete")
+    return 0
+
+
+def github_origin(path: Path) -> str | None:
+    result = run(["git", "remote", "get-url", "origin"], cwd=path, check=False)
+    if result.returncode != 0:
+        return None
+    origin = result.stdout.strip()
+    if "github.com" not in origin:
+        return None
+    return origin
+
+
+def cmd_preflight(args: argparse.Namespace) -> int:
+    target = Path(args.target).expanduser().resolve()
+    blocking: list[str] = []
+
+    if not is_git_repo(target):
+        blocking.append("not a git repository")
+    elif args.require_github and not github_origin(target):
+        blocking.append("missing GitHub origin")
+
+    repo_config = target / ".shiki" / "repo.json"
+    if args.require_github and not repo_config.exists():
+        blocking.append("missing .shiki/repo.json GitHub config")
+
+    result = {
+        "target": str(target),
+        "github_required": args.require_github,
+        "status": "blocked" if blocking else "ready",
+        "blocking_reasons": blocking,
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 1 if blocking else 0
 
 
 def should_skip(path: Path, *, target_install: bool = False) -> bool:
@@ -339,21 +462,10 @@ def cmd_install_target(args: argparse.Namespace) -> int:
     if not target.is_dir():
         raise ShikiError(f"target is not a directory: {target}")
 
-    for relative in TEMPLATE_PATHS:
-        source = ROOT / relative
-        if not source.exists():
-            warn(f"template path missing, skipped: {relative}")
-            continue
-        copy_path(source, target / relative, force=args.force, target_install=True)
+    if not args.local_only:
+        raise ShikiError("install-target is template-only; use shiki init TARGET --repo OWNER/NAME for GitHub-first setup, or pass --local-only explicitly")
 
-    for relative in TARGET_STATE_DIRECTORIES:
-        state_dir = target / relative
-        state_dir.mkdir(parents=True, exist_ok=True)
-        info(f"ensured empty state directory: {state_dir}")
-
-    if args.validate:
-        run(["python3", "scripts/validate_shiki.py"], cwd=target)
-        info("target Shiki validation passed")
+    install_template(target, force=args.force, validate=args.validate)
 
     return 0
 
@@ -420,7 +532,29 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="shiki")
     subcommands = parser.add_subparsers(dest="command", required=True)
 
-    github = subcommands.add_parser("bootstrap-github", help="Initialize and publish this Shiki repo to GitHub")
+    init = subcommands.add_parser("init", help="Install Shiki into a target repo and publish it to GitHub")
+    init.add_argument("target", help="Target repository path")
+    init.add_argument("--repo", required=True, help="GitHub repository as OWNER/NAME")
+    init.add_argument("--branch", default="main", help="Default branch, default main")
+    init.add_argument("--private", action="store_true", help="Create a private repo")
+    init.add_argument("--public", action="store_true", help=argparse.SUPPRESS)
+    init.add_argument("--force", action="store_true", help="Overwrite existing target files")
+    init.add_argument("--validate", action=argparse.BooleanOptionalAction, default=True)
+    init.add_argument("--commit", action=argparse.BooleanOptionalAction, default=True)
+    init.add_argument("--commit-message", default="shiki: initialize GitHub-first control plane")
+    init.add_argument("--push", action=argparse.BooleanOptionalAction, default=True)
+    init.add_argument("--set-secret", action=argparse.BooleanOptionalAction, default=True)
+    init.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
+    init.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
+    init.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    init.set_defaults(func=cmd_init)
+
+    preflight = subcommands.add_parser("preflight", help="Check whether a target repo is ready for Shiki")
+    preflight.add_argument("target", nargs="?", default=".", help="Target repository path")
+    preflight.add_argument("--require-github", action="store_true", help="Fail unless target is connected to GitHub")
+    preflight.set_defaults(func=cmd_preflight)
+
+    github = subcommands.add_parser("bootstrap-platform", help="Initialize and publish the Shiki platform repo to GitHub")
     github.add_argument("--repo", help="GitHub repository as OWNER/NAME")
     github.add_argument("--branch", default=None, help="Default branch, default main")
     github.add_argument("--private", action="store_true", help="Create a private repo")
@@ -434,8 +568,23 @@ def build_parser() -> argparse.ArgumentParser:
     github.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
     github.set_defaults(func=cmd_bootstrap_github)
 
-    target = subcommands.add_parser("install-target", help="Install Shiki template files into a target repo")
+    deprecated = subcommands.add_parser("bootstrap-github", help="Deprecated alias for bootstrap-platform")
+    deprecated.add_argument("--repo", help="GitHub repository as OWNER/NAME")
+    deprecated.add_argument("--branch", default=None, help="Default branch, default main")
+    deprecated.add_argument("--private", action="store_true", help="Create a private repo")
+    deprecated.add_argument("--public", action="store_true", help=argparse.SUPPRESS)
+    deprecated.add_argument("--commit", action=argparse.BooleanOptionalAction, default=True)
+    deprecated.add_argument("--commit-message", default="shiki: bootstrap control plane")
+    deprecated.add_argument("--push", action=argparse.BooleanOptionalAction, default=True)
+    deprecated.add_argument("--set-secret", action=argparse.BooleanOptionalAction, default=True)
+    deprecated.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
+    deprecated.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
+    deprecated.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    deprecated.set_defaults(func=cmd_bootstrap_github)
+
+    target = subcommands.add_parser("install-target", help="Install Shiki template files only; GitHub-first setup uses init")
     target.add_argument("target", help="Target repository path")
+    target.add_argument("--local-only", action="store_true", help="Allow template-only install without GitHub bootstrap")
     target.add_argument("--force", action="store_true", help="Overwrite existing files")
     target.add_argument("--validate", action=argparse.BooleanOptionalAction, default=True)
     target.set_defaults(func=cmd_install_target)

--- a/scripts/test_shiki_init.sh
+++ b/scripts/test_shiki_init.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/shiki-init-test-$$"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+expect_fail() {
+  if "$@" >/tmp/shiki-expected-fail.out 2>&1; then
+    echo "expected failure but command succeeded: $*" >&2
+    cat /tmp/shiki-expected-fail.out >&2
+    return 1
+  fi
+}
+
+cd "$ROOT"
+
+python3 scripts/validate_shiki.py
+python3 -m py_compile scripts/shiki.py
+python3 scripts/shiki.py --help | grep -E "init|preflight" >/dev/null
+
+git show HEAD:.claude/commands/shiki.md | grep "shiki init . --repo OWNER/NAME" >/dev/null
+grep "shiki init . --repo OWNER/NAME" .codex/skills/shiki/SKILL.md >/dev/null
+
+mkdir -p "$TMP_ROOT/missing-repo" "$TMP_ROOT/invalid-repo" "$TMP_ROOT/no-local" "$TMP_ROOT/local-only"
+
+expect_fail python3 scripts/shiki.py init "$TMP_ROOT/missing-repo"
+expect_fail python3 scripts/shiki.py init "$TMP_ROOT/invalid-repo" --repo invalid-slug
+expect_fail python3 scripts/shiki.py install-target "$TMP_ROOT/no-local"
+
+python3 scripts/shiki.py install-target "$TMP_ROOT/local-only" --local-only >/tmp/shiki-local-only.out
+python3 "$TMP_ROOT/local-only/scripts/validate_shiki.py"
+test -z "$(find "$TMP_ROOT/local-only/.shiki/tasks" -type f -name '*.json' -print -quit)"
+test -z "$(find "$TMP_ROOT/local-only/.shiki/ledger" -type f -name '*.json' -print -quit)"
+
+expect_fail python3 scripts/shiki.py preflight "$TMP_ROOT/local-only" --require-github
+
+echo "shiki init tests passed"


### PR DESCRIPTION
## Shiki Task

- Goal: G-0001
- Task: T-0006
- Runtime: Codex Front
- Risk: medium
- CCA checklist profile: PR, V, CCA, MG

## Scope

Enforce GitHub-first target setup for Shiki.

The standard setup command is now:

```bash
shiki init /path/to/repo --repo OWNER/NAME
```

`install-target` is now explicitly local-only and fails unless `--local-only` is passed.

## Acceptance

- `python3 scripts/validate_shiki.py` passes.
- `python3 -m py_compile scripts/shiki.py` passes.
- `python3 scripts/shiki.py --help` lists `init` and `preflight`.
- `python3 scripts/shiki.py init /tmp/path` exits non-zero without `--repo`.
- `python3 scripts/shiki.py init /tmp/path --repo invalid-slug` exits non-zero.
- `python3 scripts/shiki.py install-target /tmp/path` exits non-zero without `--local-only`.
- `python3 scripts/shiki.py install-target /tmp/path --local-only` still validates local-only template copies.
- `python3 scripts/shiki.py preflight /tmp/path --require-github` blocks local-only targets.
- Global `/shiki` and Codex skill now direct setup to `shiki init . --repo OWNER/NAME`.

## Evidence

- Local validation: `python3 scripts/validate_shiki.py`
- Python compile: `python3 -m py_compile scripts/shiki.py`
- Help check: `python3 scripts/shiki.py --help`
- Init missing repo check: `python3 scripts/shiki.py init /private/tmp/shiki-init-missing-repo`
- Invalid repo slug check: `python3 scripts/shiki.py init /private/tmp/shiki-init-invalid-repo --repo invalid-slug`
- Local-only guard: `python3 scripts/shiki.py install-target /private/tmp/shiki-install-no-local`
- Local-only smoke: `python3 scripts/shiki.py install-target /private/tmp/shiki-local-only-smoke --local-only`
- Preflight block: `python3 scripts/shiki.py preflight /private/tmp/shiki-local-only-smoke --require-github`
- Global command update: `python3 scripts/shiki.py install-global`

## MergeGate

- Dependencies: PR #12 global command install
- Locks: `scripts/shiki.py`, `.claude/commands/shiki.md`, `.codex/skills/shiki/SKILL.md`, `docs/agents/bootstrap-command.md`, `.shiki/tasks/T-0006.json`, `.shiki/ledger/L-0006.json`
- Risk: medium; CLI setup behavior changes
- Guardian approval: not required
