### PR TITLE
feat: add Shiki control-plane commands

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -30,6 +30,7 @@ shiki init . --repo OWNER/NAME
 
 - Treat Codex as implementer, CCA as completion judge, and MergeGate as merge authorization.
 - For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.
+- Register durable state through Shiki commands: `goal create`, `issue plan`, `lock acquire`, `dispatch check`, `worktree allocate`, `repair packet`, `task status`, and `goal complete`.
 - Do not claim completion from local work alone. Completion requires PR evidence, CCA, and MergeGate.
 - Do not use `shiki install-target` unless the user explicitly asks for a local-only template copy.
 - Do not bypass branch protection. Do not use admin merge.

--- a/.codex/skills/shiki/SKILL.md
+++ b/.codex/skills/shiki/SKILL.md
@@ -51,4 +51,12 @@ shiki init . --repo OWNER/NAME
 - `shiki install-global`
 - `shiki init /path/to/repo --repo OWNER/REPO`
 - `shiki preflight --require-github`
+- `shiki goal create --title ... --outcome ...`
+- `shiki issue plan --goal-id G-0001 --title ... --scope ... --acceptance-check ...`
+- `shiki lock acquire T-0001`
+- `shiki dispatch check T-0001`
+- `shiki worktree allocate T-0001`
+- `shiki repair packet --task-id T-0001 --pr 123 --minimal-change ... --verification-command ...`
+- `shiki task status T-0001 --status done`
+- `shiki goal complete G-0001`
 - `shiki status`

--- a/.github/workflows/shiki-validate.yml
+++ b/.github/workflows/shiki-validate.yml
@@ -20,3 +20,12 @@ jobs:
 
       - name: Validate Shiki artifacts
         run: python3 scripts/validate_shiki.py
+
+      - name: Compile Shiki CLI
+        run: python3 -m py_compile scripts/shiki.py
+
+      - name: Run Shiki init contract test
+        run: bash scripts/test_shiki_init.sh
+
+      - name: Run Shiki control-plane contract test
+        run: bash scripts/test_shiki_control_plane.sh

--- a/.shiki/ledger/L-0007.json
+++ b/.shiki/ledger/L-0007.json
@@ -1,0 +1,15 @@
+{
+  "id": "L-0007",
+  "timestamp": "2026-05-28T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0007",
+  "type": "task-registered",
+  "actor": "codex-front",
+  "summary": "Registered Shiki control-plane command implementation with TDD evidence requirements.",
+  "evidence": [
+    ".shiki/tasks/T-0007.json",
+    "scripts/test_shiki_control_plane.sh",
+    "scripts/shiki.py"
+  ],
+  "links": []
+}

--- a/.shiki/ledger/L-0008.json
+++ b/.shiki/ledger/L-0008.json
@@ -1,0 +1,20 @@
+{
+  "id": "L-0008",
+  "timestamp": "2026-05-28T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0007",
+  "type": "check",
+  "actor": "codex-front",
+  "summary": "Recorded PR #14 repair evidence for Shiki control-plane command CI coverage.",
+  "evidence": [
+    "PR #14: https://github.com/mizutani-140/shiki/pull/14",
+    "Validate Shiki mirror must run scripts/test_shiki_control_plane.sh on the PR head SHA.",
+    "Local verification: python3 scripts/validate_shiki.py",
+    "Local verification: python3 -m py_compile scripts/shiki.py",
+    "Local verification: bash scripts/test_shiki_init.sh",
+    "Local verification: bash scripts/test_shiki_control_plane.sh"
+  ],
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/14"
+  ]
+}

--- a/.shiki/tasks/T-0007.json
+++ b/.shiki/tasks/T-0007.json
@@ -1,0 +1,42 @@
+{
+  "id": "T-0007",
+  "goal_id": "G-0001",
+  "github_issue": null,
+  "title": "Implement Shiki control-plane state commands",
+  "scope": "Add GitHub-first CLI commands for Goal registration, vertical-slice task planning, lock acquisition, dispatch checks, worktree allocation, bounded repair packets, task status updates, and goal completion reports.",
+  "non_goals": [
+    "Do not bypass branch protection.",
+    "Do not require non-standard Python dependencies.",
+    "Do not create real GitHub repositories in local tests."
+  ],
+  "dependencies": [],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/test_shiki_control_plane.sh",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:docs/agents/control-commands.md",
+    "path:.shiki/tasks/T-0007.json",
+    "path:.shiki/ledger/L-0007.json"
+  ],
+  "assigned_runtime": "codex-front",
+  "risk_level": "medium",
+  "required_skills": [
+    "shiki",
+    "tdd"
+  ],
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py",
+    "python3 -m py_compile scripts/shiki.py",
+    "bash scripts/test_shiki_init.sh",
+    "bash scripts/test_shiki_control_plane.sh",
+    "python3 scripts/shiki.py --help lists control-plane subcommands through argparse help."
+  ],
+  "expected_branch": "shiki-control-plane-commands",
+  "expected_pr": null,
+  "ledger_evidence": [
+    "L-0007"
+  ],
+  "status": "review"
+}

--- a/.shiki/tasks/T-0007.json
+++ b/.shiki/tasks/T-0007.json
@@ -34,7 +34,7 @@
     "python3 scripts/shiki.py --help lists control-plane subcommands through argparse help."
   ],
   "expected_branch": "shiki-control-plane-commands",
-  "expected_pr": null,
+  "expected_pr": 14,
   "ledger_evidence": [
     "L-0007"
   ],

--- a/.shiki/tasks/T-0007.json
+++ b/.shiki/tasks/T-0007.json
@@ -13,12 +13,14 @@
   "locks": [
     "path:scripts/shiki.py",
     "path:scripts/test_shiki_control_plane.sh",
+    "path:.github/workflows/shiki-validate.yml",
     "path:.claude/commands/shiki.md",
     "path:.codex/skills/shiki/SKILL.md",
     "path:docs/agents/bootstrap-command.md",
     "path:docs/agents/control-commands.md",
     "path:.shiki/tasks/T-0007.json",
-    "path:.shiki/ledger/L-0007.json"
+    "path:.shiki/ledger/L-0007.json",
+    "path:.shiki/ledger/L-0008.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -36,7 +38,8 @@
   "expected_branch": "shiki-control-plane-commands",
   "expected_pr": 14,
   "ledger_evidence": [
-    "L-0007"
+    "L-0007",
+    "L-0008"
   ],
   "status": "review"
 }

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -83,6 +83,24 @@ the CLI directly:
 shiki status
 ```
 
+## Control Plane Commands
+
+After `shiki init` has connected the target repo to GitHub, use the control
+commands for durable execution state:
+
+```bash
+shiki goal create --title "..." --outcome "..."
+shiki issue plan --goal-id G-0001 --title "..." --scope "..." --acceptance-check "..."
+shiki lock acquire T-0001
+shiki dispatch check T-0001
+shiki worktree allocate T-0001
+shiki repair packet --task-id T-0001 --pr 123 --minimal-change "..." --verification-command "..."
+shiki task status T-0001 --status done
+shiki goal complete G-0001
+```
+
+See `docs/agents/control-commands.md` for the full sequence.
+
 ## Required GitHub Checks
 
 The bootstrap command attempts to require:

--- a/docs/agents/control-commands.md
+++ b/docs/agents/control-commands.md
@@ -1,0 +1,65 @@
+# Shiki Control Commands
+
+Shiki state transitions must go through the CLI once a repository is initialized
+with `shiki init TARGET --repo OWNER/REPO`. Control commands refuse to run when
+the target does not have a `.shiki` mirror, a git repository, and a GitHub
+`origin`.
+
+## Standard Flow
+
+```bash
+shiki goal create \
+  --title "Goal title" \
+  --outcome "Observable outcome" \
+  --completion-condition "Completion condition" \
+  --required-skill grill-with-docs \
+  --required-skill tdd
+
+shiki issue plan \
+  --goal-id G-0001 \
+  --title "Vertical slice title" \
+  --scope "Smallest end-to-end slice" \
+  --acceptance-check "Public behavior is verified" \
+  --lock "path:src/example/*" \
+  --required-skill tdd
+
+shiki lock acquire T-0001
+shiki dispatch check T-0001
+shiki worktree allocate T-0001
+```
+
+Codex then implements only the assigned task scope. If CCA rejects the PR, the
+bounded repair loop starts with a repair packet:
+
+```bash
+shiki repair packet \
+  --task-id T-0001 \
+  --pr 123 \
+  --failing-item "missing verification evidence" \
+  --minimal-change "add the requested evidence only" \
+  --verification-command "python3 scripts/validate_shiki.py"
+```
+
+When the task is actually accepted, update task state and judge the goal:
+
+```bash
+shiki task status T-0001 --status done
+shiki goal complete G-0001
+```
+
+## State Files
+
+- `.shiki/goals/*.json` records goals and completion conditions.
+- `.shiki/tasks/*.json` records vertical-slice tasks.
+- `.shiki/dag/*.json` records dependency edges.
+- `.shiki/locks/*.json` records active lock ownership.
+- `.shiki/worktrees/*.json` records assigned work surfaces.
+- `.shiki/repairs/*.json` records bounded repair packets.
+- `.shiki/reports/*.json` records goal completion judgments.
+- `.shiki/ledger/*.json` records durable evidence for every transition.
+
+## Authority Boundary
+
+Codex may implement and repair only after `dispatch check` is green. CCA judges
+completion from PR evidence. MergeGate authorizes state transitions and merge
+readiness. GitHub branch protection remains the hard gate.

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -8,8 +8,10 @@ command can run before a target repository has installed dependencies.
 from __future__ import annotations
 
 import argparse
+from datetime import datetime, timezone
 import json
 import os
+from typing import Any
 import shutil
 import subprocess
 import sys
@@ -58,9 +60,12 @@ DEFAULT_CODEX_SKILL_PATH = "~/.codex/skills/shiki/SKILL.md"
 TARGET_STATE_DIRECTORIES = [
     ".shiki/goals",
     ".shiki/tasks",
+    ".shiki/dag",
     ".shiki/ledger",
     ".shiki/locks",
     ".shiki/worktrees",
+    ".shiki/repairs",
+    ".shiki/reports",
 ]
 GITHUB_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -269,6 +274,483 @@ def load_default_config() -> dict[str, str]:
     if not LOCAL_CONFIG.exists():
         return {}
     return json.loads(LOCAL_CONFIG.read_text(encoding="utf-8"))
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def target_path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
+def shiki_path(target: Path, *parts: str) -> Path:
+    return target / ".shiki" / Path(*parts)
+
+
+def ensure_control_dirs(target: Path) -> None:
+    for relative in TARGET_STATE_DIRECTORIES:
+        (target / relative).mkdir(parents=True, exist_ok=True)
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise ShikiError(f"missing file: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ShikiError(f"expected JSON object: {path}")
+    return data
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def print_json(data: dict[str, Any]) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def slugify(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9]+", "-", value.lower()).strip("-")
+    return slug[:48] or "task"
+
+
+def scan_ids(target: Path, prefix: str) -> list[int]:
+    pattern = re.compile(rf"\b{re.escape(prefix)}-([0-9]{{4,}})\b")
+    numbers: list[int] = []
+    base = target / ".shiki"
+    if not base.exists():
+        return numbers
+    for path in base.rglob("*.json"):
+        for match in pattern.finditer(path.name):
+            numbers.append(int(match.group(1)))
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        for match in pattern.finditer(text):
+            numbers.append(int(match.group(1)))
+    return numbers
+
+
+def next_control_id(target: Path, prefix: str) -> str:
+    number = max(scan_ids(target, prefix), default=0) + 1
+    return f"{prefix}-{number:04d}"
+
+
+def load_task(target: Path, task_id: str) -> dict[str, Any]:
+    return read_json(shiki_path(target, "tasks", f"{task_id}.json"))
+
+
+def load_goal(target: Path, goal_id: str) -> dict[str, Any]:
+    return read_json(shiki_path(target, "goals", f"{goal_id}.json"))
+
+
+def task_files(target: Path) -> list[Path]:
+    directory = shiki_path(target, "tasks")
+    if not directory.exists():
+        return []
+    return sorted(path for path in directory.glob("*.json") if path.is_file())
+
+
+def tasks_for_goal(target: Path, goal_id: str) -> list[dict[str, Any]]:
+    tasks: list[dict[str, Any]] = []
+    for path in task_files(target):
+        data = read_json(path)
+        if data.get("goal_id") == goal_id:
+            tasks.append(data)
+    return tasks
+
+
+def has_active_lock_conflict(target: Path, task_id: str, locks: list[str]) -> list[str]:
+    conflicts: list[str] = []
+    directory = shiki_path(target, "locks")
+    if not directory.exists():
+        return conflicts
+    requested = set(locks)
+    for path in sorted(directory.glob("*.json")):
+        data = read_json(path)
+        if data.get("task_id") == task_id or data.get("state") != "active":
+            continue
+        overlap = requested.intersection(set(data.get("locks", [])))
+        for lock in sorted(overlap):
+            conflicts.append(f"{lock} held by {data.get('task_id')}")
+    return conflicts
+
+
+def lock_record(target: Path, task_id: str) -> dict[str, Any] | None:
+    path = shiki_path(target, "locks", f"{task_id}.json")
+    if not path.exists():
+        return None
+    return read_json(path)
+
+
+def worktree_record(target: Path, task_id: str) -> dict[str, Any] | None:
+    path = shiki_path(target, "worktrees", f"{task_id}.json")
+    if not path.exists():
+        return None
+    return read_json(path)
+
+
+def require_github_first_target(target: Path) -> None:
+    if not (target / ".shiki").exists():
+        raise ShikiError(f"missing .shiki mirror in {target}; run shiki init TARGET --repo OWNER/NAME")
+    if not is_git_repo(target):
+        raise ShikiError("Shiki control commands require a git repository; run shiki init TARGET --repo OWNER/NAME")
+    if not github_origin(target):
+        raise ShikiError("Shiki control commands require a GitHub origin; run shiki init TARGET --repo OWNER/NAME")
+
+
+def append_ledger(
+    target: Path,
+    *,
+    goal_id: str,
+    ledger_type: str,
+    summary: str,
+    evidence: list[str],
+    task_id: str | None = None,
+    links: list[str] | None = None,
+) -> str:
+    ledger_id = next_control_id(target, "L")
+    payload: dict[str, Any] = {
+        "id": ledger_id,
+        "timestamp": utc_now(),
+        "goal_id": goal_id,
+        "task_id": task_id,
+        "type": ledger_type,
+        "actor": "shiki-cli",
+        "summary": summary,
+        "evidence": evidence,
+        "links": links or [],
+    }
+    write_json(shiki_path(target, "ledger", f"{ledger_id}.json"), payload)
+    return ledger_id
+
+
+def cmd_goal_create(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+
+    goal_id = next_control_id(target, "G")
+    completion_conditions = args.completion_condition or [args.outcome]
+    acceptance_evidence = args.acceptance_evidence or [
+        "GitHub Issue records the goal.",
+        "Task DAG is registered in .shiki/dag.",
+        "CCA verdict and MergeGate evidence are recorded before completion.",
+    ]
+    payload = {
+        "id": goal_id,
+        "github_issue": args.github_issue,
+        "title": args.title,
+        "outcome": args.outcome,
+        "completion_conditions": completion_conditions,
+        "non_goals": args.non_goal or [],
+        "risk_level": args.risk_level,
+        "required_skills": args.required_skill or [],
+        "acceptance_evidence": acceptance_evidence,
+        "status": "planned",
+        "created_at": utc_now(),
+    }
+    goal_file = shiki_path(target, "goals", f"{goal_id}.json")
+    write_json(goal_file, payload)
+    ledger_id = append_ledger(
+        target,
+        goal_id=goal_id,
+        ledger_type="goal-created",
+        summary=f"Goal registered: {args.title}",
+        evidence=[str(goal_file.relative_to(target))],
+    )
+    print_json({"goal_id": goal_id, "goal_file": str(goal_file), "ledger_id": ledger_id, "status": "planned"})
+    return 0
+
+
+def cmd_issue_plan(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    load_goal(target, args.goal_id)
+
+    task_id = next_control_id(target, "T")
+    branch = args.expected_branch or f"shiki/{task_id.lower()}-{slugify(args.title)}"
+    ledger_id = append_ledger(
+        target,
+        goal_id=args.goal_id,
+        task_id=task_id,
+        ledger_type="task-registered",
+        summary=f"Task registered: {args.title}",
+        evidence=[f".shiki/tasks/{task_id}.json"],
+    )
+    payload = {
+        "id": task_id,
+        "goal_id": args.goal_id,
+        "github_issue": args.github_issue,
+        "title": args.title,
+        "scope": args.scope,
+        "non_goals": args.non_goal or [],
+        "dependencies": args.dependency or [],
+        "locks": args.lock or [],
+        "assigned_runtime": args.runtime,
+        "risk_level": args.risk_level,
+        "required_skills": args.required_skill or [],
+        "acceptance_checks": args.acceptance_check,
+        "expected_branch": branch,
+        "expected_pr": args.expected_pr,
+        "ledger_evidence": [ledger_id],
+        "status": "planned",
+    }
+    task_file = shiki_path(target, "tasks", f"{task_id}.json")
+    write_json(task_file, payload)
+
+    dag_file = shiki_path(target, "dag", f"{args.goal_id}.json")
+    dag = {"goal_id": args.goal_id, "nodes": [], "edges": []}
+    if dag_file.exists():
+        dag = read_json(dag_file)
+    nodes = list(dict.fromkeys([*dag.get("nodes", []), task_id]))
+    existing_edges = dag.get("edges", [])
+    new_edges = [{"from": dep, "to": task_id, "reason": "declared dependency"} for dep in args.dependency or []]
+    dag.update({"nodes": nodes, "edges": existing_edges + new_edges})
+    write_json(dag_file, dag)
+
+    print_json({"task_id": task_id, "task_file": str(task_file), "dag_file": str(dag_file), "ledger_id": ledger_id})
+    return 0
+
+
+def cmd_lock_acquire(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    task = load_task(target, args.task_id)
+    locks = list(task.get("locks", []))
+    conflicts = has_active_lock_conflict(target, args.task_id, locks)
+
+    result = {
+        "task_id": args.task_id,
+        "locks_requested": locks,
+        "locks_granted": not conflicts,
+        "blocking_reasons": conflicts,
+    }
+    if conflicts:
+        print_json(result)
+        return 1
+
+    record = {
+        "task_id": args.task_id,
+        "goal_id": task["goal_id"],
+        "locks": locks,
+        "state": "active",
+        "owner": args.owner,
+        "created_at": utc_now(),
+    }
+    lock_file = shiki_path(target, "locks", f"{args.task_id}.json")
+    write_json(lock_file, record)
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=args.task_id,
+        ledger_type="lock",
+        summary=f"Locks acquired for {args.task_id}",
+        evidence=[str(lock_file.relative_to(target))],
+    )
+    task["status"] = "ready"
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{args.task_id}.json"), task)
+    result.update({"lock_file": str(lock_file), "ledger_id": ledger_id})
+    print_json(result)
+    return 0
+
+
+def cmd_dispatch_check(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    task = load_task(target, args.task_id)
+
+    dependency_tasks = [load_task(target, dep) for dep in task.get("dependencies", [])]
+    dependencies_complete = all(dep.get("status") == "done" for dep in dependency_tasks)
+    lock = lock_record(target, args.task_id)
+    task_locks = set(task.get("locks", []))
+    locks_granted = not task_locks or bool(lock and lock.get("state") == "active" and task_locks.issubset(set(lock.get("locks", []))))
+    worktree_allocated = worktree_record(target, args.task_id) is not None
+    guardian_required = task.get("risk_level") in {"high", "critical"}
+    verification_present = bool(task.get("acceptance_checks"))
+    handoff_complete = all(bool(task.get(key)) for key in ("title", "scope", "expected_branch", "assigned_runtime"))
+
+    blocking: list[str] = []
+    if not dependencies_complete:
+        blocking.append("dependencies are not complete")
+    if not locks_granted:
+        blocking.append("locks are not granted")
+    if guardian_required:
+        blocking.append("guardian approval required for high/critical risk")
+    if not verification_present:
+        blocking.append("verification profile is missing")
+    if not handoff_complete:
+        blocking.append("handoff is incomplete")
+    if args.require_worktree and not worktree_allocated:
+        blocking.append("worktree is not allocated")
+
+    result = {
+        "dispatchable": not blocking,
+        "task_id": args.task_id,
+        "runtime": task.get("assigned_runtime"),
+        "dependencies_complete": dependencies_complete,
+        "locks_granted": locks_granted,
+        "guardian_approval_required": guardian_required,
+        "verification_profile_present": verification_present,
+        "handoff_complete": handoff_complete,
+        "worktree_allocated": worktree_allocated,
+        "blocking_reasons": blocking,
+    }
+    print_json(result)
+    return 1 if blocking else 0
+
+
+def cmd_worktree_allocate(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    task = load_task(target, args.task_id)
+    branch = args.branch or task["expected_branch"]
+    worktree_path = Path(args.path).expanduser().resolve() if args.path else (target.parent / ".worktrees" / slugify(branch)).resolve()
+    record = {
+        "task_id": args.task_id,
+        "goal_id": task["goal_id"],
+        "branch": branch,
+        "path": str(worktree_path),
+        "runtime": task["assigned_runtime"],
+        "state": "registered",
+        "locks": task.get("locks", []),
+        "created_by": "shiki-cli",
+        "created_at": utc_now(),
+        "pr": task.get("expected_pr"),
+    }
+    if args.create and not worktree_path.exists():
+        run(["git", "worktree", "add", "-b", branch, str(worktree_path)], cwd=target)
+        record["state"] = "active"
+    worktree_file = shiki_path(target, "worktrees", f"{args.task_id}.json")
+    write_json(worktree_file, record)
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=args.task_id,
+        ledger_type="handoff",
+        summary=f"Worktree allocated for {args.task_id}",
+        evidence=[str(worktree_file.relative_to(target))],
+    )
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{args.task_id}.json"), task)
+    print_json({"task_id": args.task_id, "worktree_file": str(worktree_file), "ledger_id": ledger_id, "record": record})
+    return 0
+
+
+def cmd_repair_packet(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    task = load_task(target, args.task_id)
+    if args.attempt > 3:
+        raise ShikiError("repair attempt limit is 3")
+
+    repair_id = next_control_id(target, "RP")
+    packet = {
+        "repair_id": repair_id,
+        "goal_id": task["goal_id"],
+        "task_id": args.task_id,
+        "pr": args.pr,
+        "attempt": args.attempt,
+        "failing_checklist_items": args.failing_item or [],
+        "failing_acceptance_criteria": args.failing_acceptance_criteria or [],
+        "minimal_required_changes": args.minimal_change,
+        "prohibited_changes": args.prohibited_change or [],
+        "required_skill": args.required_skill,
+        "verification_commands": args.verification_command,
+        "evidence_required": args.evidence_required or ["Attach verification output to the PR."],
+        "stop_condition": args.stop_condition,
+        "created_at": utc_now(),
+    }
+    repair_file = shiki_path(target, "repairs", f"{repair_id}.json")
+    write_json(repair_file, packet)
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=args.task_id,
+        ledger_type="repair",
+        summary=f"Repair packet {repair_id} created for PR #{args.pr}",
+        evidence=[str(repair_file.relative_to(target))],
+    )
+    task["status"] = "repair-needed"
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{args.task_id}.json"), task)
+    print_json({"repair_id": repair_id, "repair_file": str(repair_file), "ledger_id": ledger_id})
+    return 0
+
+
+def cmd_task_status(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    task = load_task(target, args.task_id)
+    task["status"] = args.status
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=args.task_id,
+        ledger_type="check",
+        summary=f"Task {args.task_id} status changed to {args.status}",
+        evidence=[f".shiki/tasks/{args.task_id}.json"],
+    )
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{args.task_id}.json"), task)
+    print_json({"task_id": args.task_id, "status": args.status, "ledger_id": ledger_id})
+    return 0
+
+
+def cmd_goal_complete(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    goal = load_goal(target, args.goal_id)
+    tasks = tasks_for_goal(target, args.goal_id)
+    incomplete = [task["id"] for task in tasks if task.get("status") != "done"]
+    blocking: list[str] = []
+    if not tasks:
+        blocking.append("goal has no tasks")
+    if incomplete:
+        blocking.append(f"incomplete tasks: {', '.join(incomplete)}")
+
+    status = "blocked" if blocking else "complete"
+    report_id = next_control_id(target, "R")
+    report = {
+        "id": report_id,
+        "goal_id": args.goal_id,
+        "status": status,
+        "summary": args.summary or f"Goal {args.goal_id} {status}: {goal['title']}",
+        "evidence": [f".shiki/tasks/{task['id']}.json" for task in tasks],
+        "blocking_reasons": blocking,
+        "mergegate": {
+            "dependencies": "pass" if not blocking else "blocked",
+            "locks": "pass",
+            "checks": "pass" if not blocking else "blocked",
+            "review": "recorded",
+            "ledger": "pass",
+            "risk": goal.get("risk_level", "low"),
+        },
+        "created_at": utc_now(),
+    }
+    report_file = shiki_path(target, "reports", f"{report_id}.json")
+    write_json(report_file, report)
+    ledger_id = append_ledger(
+        target,
+        goal_id=args.goal_id,
+        ledger_type="completion",
+        summary=report["summary"],
+        evidence=[str(report_file.relative_to(target))],
+    )
+    goal["status"] = status
+    goal.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "goals", f"{args.goal_id}.json"), goal)
+    print_json({"goal_id": args.goal_id, "status": status, "report_file": str(report_file), "ledger_id": ledger_id, "blocking_reasons": blocking})
+    return 1 if blocking else 0
 
 
 def cmd_bootstrap_github(args: argparse.Namespace) -> int:
@@ -603,6 +1085,96 @@ def build_parser() -> argparse.ArgumentParser:
 
     status = subcommands.add_parser("status", help="Show local Shiki CLI configuration")
     status.set_defaults(func=cmd_status)
+
+    goal = subcommands.add_parser("goal", help="Manage Shiki goals")
+    goal_subcommands = goal.add_subparsers(dest="goal_command", required=True)
+    goal_create = goal_subcommands.add_parser("create", help="Register a GitHub-first Shiki goal")
+    goal_create.add_argument("--target", default=".", help="Target repository path")
+    goal_create.add_argument("--title", required=True)
+    goal_create.add_argument("--outcome", required=True)
+    goal_create.add_argument("--completion-condition", action="append", default=[])
+    goal_create.add_argument("--non-goal", action="append", default=[])
+    goal_create.add_argument("--risk-level", default="low", choices=["low", "medium", "high", "critical"])
+    goal_create.add_argument("--required-skill", action="append", default=[])
+    goal_create.add_argument("--acceptance-evidence", action="append", default=[])
+    goal_create.add_argument("--github-issue", type=int)
+    goal_create.set_defaults(func=cmd_goal_create)
+
+    goal_complete = goal_subcommands.add_parser("complete", help="Judge goal completion from task evidence")
+    goal_complete.add_argument("--target", default=".", help="Target repository path")
+    goal_complete.add_argument("goal_id")
+    goal_complete.add_argument("--summary")
+    goal_complete.set_defaults(func=cmd_goal_complete)
+
+    issue = subcommands.add_parser("issue", help="Plan vertical-slice Shiki tasks")
+    issue_subcommands = issue.add_subparsers(dest="issue_command", required=True)
+    issue_plan = issue_subcommands.add_parser("plan", help="Register a task and update the task DAG")
+    issue_plan.add_argument("--target", default=".", help="Target repository path")
+    issue_plan.add_argument("--goal-id", required=True)
+    issue_plan.add_argument("--title", required=True)
+    issue_plan.add_argument("--scope", required=True)
+    issue_plan.add_argument("--non-goal", action="append", default=[])
+    issue_plan.add_argument("--dependency", action="append", default=[])
+    issue_plan.add_argument("--lock", action="append", default=[])
+    issue_plan.add_argument("--runtime", default="codex", choices=["codex", "claude-code", "github-actions", "hermes-runner", "human", "other"])
+    issue_plan.add_argument("--risk-level", default="low", choices=["low", "medium", "high", "critical"])
+    issue_plan.add_argument("--required-skill", action="append", default=[])
+    issue_plan.add_argument("--acceptance-check", action="append", required=True)
+    issue_plan.add_argument("--expected-branch")
+    issue_plan.add_argument("--expected-pr", type=int)
+    issue_plan.add_argument("--github-issue", type=int)
+    issue_plan.set_defaults(func=cmd_issue_plan)
+
+    lock = subcommands.add_parser("lock", help="Manage Shiki task locks")
+    lock_subcommands = lock.add_subparsers(dest="lock_command", required=True)
+    lock_acquire = lock_subcommands.add_parser("acquire", help="Acquire declared locks for a task")
+    lock_acquire.add_argument("--target", default=".", help="Target repository path")
+    lock_acquire.add_argument("--owner", default="shiki-cli")
+    lock_acquire.add_argument("task_id")
+    lock_acquire.set_defaults(func=cmd_lock_acquire)
+
+    dispatch = subcommands.add_parser("dispatch", help="Run dispatch readiness checks")
+    dispatch_subcommands = dispatch.add_subparsers(dest="dispatch_command", required=True)
+    dispatch_check = dispatch_subcommands.add_parser("check", help="Check whether a task may be dispatched")
+    dispatch_check.add_argument("--target", default=".", help="Target repository path")
+    dispatch_check.add_argument("--require-worktree", action="store_true")
+    dispatch_check.add_argument("task_id")
+    dispatch_check.set_defaults(func=cmd_dispatch_check)
+
+    worktree = subcommands.add_parser("worktree", help="Manage Shiki worktree records")
+    worktree_subcommands = worktree.add_subparsers(dest="worktree_command", required=True)
+    worktree_allocate = worktree_subcommands.add_parser("allocate", help="Allocate a task worktree record")
+    worktree_allocate.add_argument("--target", default=".", help="Target repository path")
+    worktree_allocate.add_argument("--branch")
+    worktree_allocate.add_argument("--path")
+    worktree_allocate.add_argument("--create", action="store_true", help="Also run git worktree add")
+    worktree_allocate.add_argument("task_id")
+    worktree_allocate.set_defaults(func=cmd_worktree_allocate)
+
+    repair = subcommands.add_parser("repair", help="Manage bounded repair packets")
+    repair_subcommands = repair.add_subparsers(dest="repair_command", required=True)
+    repair_packet = repair_subcommands.add_parser("packet", help="Create a bounded repair packet")
+    repair_packet.add_argument("--target", default=".", help="Target repository path")
+    repair_packet.add_argument("--task-id", required=True)
+    repair_packet.add_argument("--pr", required=True, type=int)
+    repair_packet.add_argument("--attempt", default=1, type=int)
+    repair_packet.add_argument("--failing-item", action="append", default=[])
+    repair_packet.add_argument("--failing-acceptance-criteria", action="append", default=[])
+    repair_packet.add_argument("--minimal-change", action="append", required=True)
+    repair_packet.add_argument("--prohibited-change", action="append", default=[])
+    repair_packet.add_argument("--required-skill", default="tdd", choices=["tdd", "diagnose", "grill-with-docs", "improve-codebase-architecture", "none"])
+    repair_packet.add_argument("--verification-command", action="append", required=True)
+    repair_packet.add_argument("--evidence-required", action="append", default=[])
+    repair_packet.add_argument("--stop-condition", default="Stop after this packet is satisfied or after three failed attempts.")
+    repair_packet.set_defaults(func=cmd_repair_packet)
+
+    task = subcommands.add_parser("task", help="Manage Shiki task state")
+    task_subcommands = task.add_subparsers(dest="task_command", required=True)
+    task_status = task_subcommands.add_parser("status", help="Set a task status and record ledger evidence")
+    task_status.add_argument("--target", default=".", help="Target repository path")
+    task_status.add_argument("task_id")
+    task_status.add_argument("--status", required=True, choices=["planned", "ready", "running", "blocked", "review", "repair-needed", "done"])
+    task_status.set_defaults(func=cmd_task_status)
 
     return parser
 

--- a/scripts/test_shiki_control_plane.sh
+++ b/scripts/test_shiki_control_plane.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/shiki-control-plane-test-$$"
+TARGET="$TMP_ROOT/target"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+json_get() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"
+}
+
+cd "$ROOT"
+
+python3 scripts/validate_shiki.py
+python3 -m py_compile scripts/shiki.py
+python3 scripts/shiki.py --help | grep -E "goal|issue|dispatch|repair" >/dev/null
+python3 scripts/shiki.py goal --help | grep "complete" >/dev/null
+python3 scripts/shiki.py issue --help | grep "plan" >/dev/null
+grep "goal create" .codex/skills/shiki/SKILL.md >/dev/null
+grep "Register durable state" .claude/commands/shiki.md >/dev/null
+
+mkdir -p "$TARGET"
+python3 scripts/shiki.py install-target "$TARGET" --local-only >/tmp/shiki-control-install.out
+
+cd "$TARGET"
+git init -b main >/tmp/shiki-control-git-init.out
+git remote add origin https://github.com/example/shiki-control-plane-test.git
+
+python3 "$ROOT/scripts/shiki.py" goal create \
+  --target "$TARGET" \
+  --title "Ship searchable audit trail" \
+  --outcome "Operators can search task evidence from GitHub PR records" \
+  --completion-condition "All task slices have done status" \
+  --completion-condition "CCA and MergeGate evidence exists" \
+  --required-skill grill-with-docs \
+  --required-skill tdd \
+  >/tmp/shiki-goal-create.json
+
+GOAL_ID="$(json_get /tmp/shiki-goal-create.json goal_id)"
+test -f "$TARGET/.shiki/goals/$GOAL_ID.json"
+
+python3 "$ROOT/scripts/shiki.py" issue plan \
+  --target "$TARGET" \
+  --goal-id "$GOAL_ID" \
+  --title "Search audit evidence by task" \
+  --scope "Add the smallest vertical slice for searching task evidence" \
+  --acceptance-check "A user can query task evidence by task id" \
+  --acceptance-check "Verification command records evidence" \
+  --lock "path:src/audit/*" \
+  --required-skill tdd \
+  >/tmp/shiki-issue-plan.json
+
+TASK_ID="$(json_get /tmp/shiki-issue-plan.json task_id)"
+test -f "$TARGET/.shiki/tasks/$TASK_ID.json"
+test -f "$TARGET/.shiki/dag/$GOAL_ID.json"
+
+python3 "$ROOT/scripts/shiki.py" lock acquire --target "$TARGET" "$TASK_ID" >/tmp/shiki-lock.json
+python3 "$ROOT/scripts/shiki.py" dispatch check --target "$TARGET" "$TASK_ID" >/tmp/shiki-dispatch.json
+python3 "$ROOT/scripts/shiki.py" worktree allocate --target "$TARGET" "$TASK_ID" >/tmp/shiki-worktree.json
+test -f "$TARGET/.shiki/worktrees/$TASK_ID.json"
+
+python3 "$ROOT/scripts/shiki.py" repair packet \
+  --target "$TARGET" \
+  --task-id "$TASK_ID" \
+  --pr 123 \
+  --failing-item "missing verification evidence" \
+  --minimal-change "add the requested verification evidence only" \
+  --verification-command "python3 scripts/validate_shiki.py" \
+  >/tmp/shiki-repair.json
+
+python3 "$ROOT/scripts/shiki.py" task status --target "$TARGET" "$TASK_ID" --status done >/tmp/shiki-task-status.json
+python3 "$ROOT/scripts/shiki.py" goal complete --target "$TARGET" "$GOAL_ID" >/tmp/shiki-goal-complete.json
+
+python3 "$TARGET/scripts/validate_shiki.py"
+
+echo "shiki control-plane tests passed"


### PR DESCRIPTION
## Shiki
Goal: G-0001
Task: T-0007
CCA checklist profile: PR, TDD, V, CCA

## Scope
Add GitHub-first Shiki control commands for goal registration, vertical-slice task planning, lock acquisition, dispatch readiness, worktree allocation, bounded repair packet creation, task status updates, and goal completion reports.

## Non-goals
- Do not bypass branch protection.
- Do not require non-standard Python dependencies.
- Do not create real GitHub repositories in local tests.

## Acceptance
- shiki goal create registers durable goal state and ledger evidence.
- shiki issue plan creates a vertical-slice task and updates the task DAG.
- shiki lock acquire blocks conflicting active locks and records lock evidence.
- shiki dispatch check emits machine-readable dispatch guard JSON.
- shiki worktree allocate records assigned branch/worktree state.
- shiki repair packet creates bounded repair packets with attempt limits.
- shiki task status and shiki goal complete record completion evidence.

## Evidence
- python3 scripts/validate_shiki.py
- python3 -m py_compile scripts/shiki.py
- bash scripts/test_shiki_init.sh
- bash scripts/test_shiki_control_plane.sh
- CI: Validate Shiki mirror includes Run Shiki control-plane contract test.

## Ledger evidence
- L-0007: task registration evidence for T-0007.
- L-0008: PR #14 and CI coverage evidence for the control-plane contract test.

## MergeGate
- Locks: path:scripts/shiki.py, path:scripts/test_shiki_control_plane.sh, path:.github/workflows/shiki-validate.yml, path:.claude/commands/shiki.md, path:.codex/skills/shiki/SKILL.md, path:docs/agents/bootstrap-command.md, path:docs/agents/control-commands.md, path:.shiki/tasks/T-0007.json, path:.shiki/ledger/L-0007.json, path:.shiki/ledger/L-0008.json
- Risk: medium
- CCA required: yes
- Merge only after required checks pass.