### PR TITLE
feat: orchestrate Shiki plans into runs

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -30,7 +30,9 @@ shiki init . --repo OWNER/NAME
 
 - Treat Codex as implementer, CCA as completion judge, and MergeGate as merge authorization.
 - For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.
+- After `grill-with-docs` is settled, prefer `shiki plan ingest` and `shiki run` over manually calling each lower-level command.
 - Register durable state through Shiki commands: `goal create`, `issue plan`, `lock acquire`, `dispatch check`, `worktree allocate`, `repair packet`, `task status`, and `goal complete`.
+- Use `shiki github issue`, `shiki github pr`, and `shiki handoff` to create durable GitHub and Codex evidence instead of free-form handoff text.
 - Do not claim completion from local work alone. Completion requires PR evidence, CCA, and MergeGate.
 - Do not use `shiki install-target` unless the user explicitly asks for a local-only template copy.
 - Do not bypass branch protection. Do not use admin merge.

--- a/.codex/skills/shiki/SKILL.md
+++ b/.codex/skills/shiki/SKILL.md
@@ -38,6 +38,7 @@ shiki init . --repo OWNER/NAME
 ## Rules
 
 - For non-trivial goals, enter through `grill-with-docs`.
+- Convert the settled `grill-with-docs` result into a machine-readable plan and run it with `shiki plan ingest` followed by `shiki run`.
 - Use Context and Impact before implementation.
 - Keep tasks as vertical slices with explicit locks and verification.
 - Use TDD for implementation work when behavior changes.
@@ -51,11 +52,18 @@ shiki init . --repo OWNER/NAME
 - `shiki install-global`
 - `shiki init /path/to/repo --repo OWNER/REPO`
 - `shiki preflight --require-github`
+- `shiki plan guide --prompt "..."`
+- `shiki plan ingest --plan-file PLAN.json`
+- `shiki run --plan P-0001`
 - `shiki goal create --title ... --outcome ...`
 - `shiki issue plan --goal-id G-0001 --title ... --scope ... --acceptance-check ...`
 - `shiki lock acquire T-0001`
 - `shiki dispatch check T-0001`
 - `shiki worktree allocate T-0001`
+- `shiki github issue --task-id T-0001`
+- `shiki github pr --task-id T-0001`
+- `shiki handoff task T-0001`
+- `shiki handoff repair RP-0001`
 - `shiki repair packet --task-id T-0001 --pr 123 --minimal-change ... --verification-command ...`
 - `shiki task status T-0001 --status done`
 - `shiki goal complete G-0001`

--- a/.github/workflows/shiki-validate.yml
+++ b/.github/workflows/shiki-validate.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run Shiki control-plane contract test
         run: bash scripts/test_shiki_control_plane.sh
+
+      - name: Run Shiki run orchestrator contract test
+        run: bash scripts/test_shiki_run_orchestrator.sh

--- a/.shiki/ledger/L-0009.json
+++ b/.shiki/ledger/L-0009.json
@@ -1,0 +1,15 @@
+{
+  "id": "L-0009",
+  "timestamp": "2026-05-28T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0008",
+  "type": "task-registered",
+  "actor": "codex-front",
+  "summary": "Registered Shiki plan ingestion and run orchestration implementation with TDD evidence requirements.",
+  "evidence": [
+    ".shiki/tasks/T-0008.json",
+    "scripts/test_shiki_run_orchestrator.sh",
+    "scripts/shiki.py"
+  ],
+  "links": []
+}

--- a/.shiki/ledger/L-0010.json
+++ b/.shiki/ledger/L-0010.json
@@ -1,0 +1,21 @@
+{
+  "id": "L-0010",
+  "timestamp": "2026-05-28T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0008",
+  "type": "check",
+  "actor": "codex-front",
+  "summary": "Recorded PR #15 evidence for Shiki plan/run orchestration and CI coverage.",
+  "evidence": [
+    "PR #15: https://github.com/mizutani-140/shiki/pull/15",
+    "Validate Shiki mirror must run scripts/test_shiki_run_orchestrator.sh on the PR head SHA.",
+    "Local verification: python3 scripts/validate_shiki.py",
+    "Local verification: python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py",
+    "Local verification: bash scripts/test_shiki_init.sh",
+    "Local verification: bash scripts/test_shiki_control_plane.sh",
+    "Local verification: bash scripts/test_shiki_run_orchestrator.sh"
+  ],
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/15"
+  ]
+}

--- a/.shiki/schemas/plan.schema.json
+++ b/.shiki/schemas/plan.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiki.local/schemas/plan.schema.json",
+  "title": "Shiki Plan",
+  "type": "object",
+  "required": ["id", "title", "outcome", "grill_with_docs", "tasks"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^P-[0-9]{4,}$" },
+    "title": { "type": "string", "minLength": 1 },
+    "outcome": { "type": "string", "minLength": 1 },
+    "completion_conditions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "non_goals": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "risk_level": { "enum": ["low", "medium", "high", "critical"] },
+    "required_skills": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "grill_with_docs": {
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["complete"] },
+        "source": { "type": "string" },
+        "decisions": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "additionalProperties": true
+    },
+    "tasks": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["title", "scope", "acceptance_checks"],
+        "properties": {
+          "title": { "type": "string", "minLength": 1 },
+          "scope": { "type": "string", "minLength": 1 },
+          "acceptance_checks": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 },
+            "minItems": 1
+          },
+          "dependencies": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "locks": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/.shiki/schemas/run.schema.json
+++ b/.shiki/schemas/run.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiki.local/schemas/run.schema.json",
+  "title": "Shiki Run",
+  "type": "object",
+  "required": [
+    "id",
+    "plan_id",
+    "goal_id",
+    "task_ids",
+    "dispatchable_task_ids",
+    "blocked_task_ids",
+    "dag",
+    "worktrees",
+    "created_at"
+  ],
+  "properties": {
+    "id": { "type": "string", "pattern": "^RUN-[0-9]{4,}$" },
+    "plan_id": { "type": "string", "pattern": "^P-[0-9]{4,}$" },
+    "goal_id": { "type": "string", "pattern": "^G-[0-9]{4,}$" },
+    "task_ids": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^T-[0-9]{4,}$" }
+    },
+    "dispatchable_task_ids": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^T-[0-9]{4,}$" }
+    },
+    "blocked_task_ids": { "type": "object" },
+    "dag": { "type": "string", "minLength": 1 },
+    "worktrees": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "created_at": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": true
+}

--- a/.shiki/tasks/T-0008.json
+++ b/.shiki/tasks/T-0008.json
@@ -25,7 +25,8 @@
     "path:.shiki/schemas/plan.schema.json",
     "path:.shiki/schemas/run.schema.json",
     "path:.shiki/tasks/T-0008.json",
-    "path:.shiki/ledger/L-0009.json"
+    "path:.shiki/ledger/L-0009.json",
+    "path:.shiki/ledger/L-0010.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -43,9 +44,10 @@
     "PR evidence includes CCA and MergeGate success."
   ],
   "expected_branch": "shiki-plan-run-orchestrator",
-  "expected_pr": null,
+  "expected_pr": 15,
   "ledger_evidence": [
-    "L-0009"
+    "L-0009",
+    "L-0010"
   ],
   "status": "review"
 }

--- a/.shiki/tasks/T-0008.json
+++ b/.shiki/tasks/T-0008.json
@@ -1,0 +1,51 @@
+{
+  "id": "T-0008",
+  "goal_id": "G-0001",
+  "github_issue": null,
+  "title": "Orchestrate grill-with-docs plans into Shiki runs",
+  "scope": "Add plan ingestion, guided plan prompting, shiki run orchestration, GitHub issue and PR evidence creation, and Codex task/repair handoff generation so settled grill-with-docs plans can drive the control plane without manually calling every primitive.",
+  "non_goals": [
+    "Do not bypass branch protection.",
+    "Do not require non-standard Python dependencies.",
+    "Do not create real GitHub issues or PRs in local tests.",
+    "Do not implement an always-on daemon or background service in this slice."
+  ],
+  "dependencies": [
+    "T-0007"
+  ],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/validate_shiki.py",
+    "path:scripts/test_shiki_run_orchestrator.sh",
+    "path:.github/workflows/shiki-validate.yml",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:docs/agents/control-commands.md",
+    "path:.shiki/schemas/plan.schema.json",
+    "path:.shiki/schemas/run.schema.json",
+    "path:.shiki/tasks/T-0008.json",
+    "path:.shiki/ledger/L-0009.json"
+  ],
+  "assigned_runtime": "codex-front",
+  "risk_level": "medium",
+  "required_skills": [
+    "shiki",
+    "tdd"
+  ],
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py",
+    "python3 -m py_compile scripts/shiki.py",
+    "bash scripts/test_shiki_init.sh",
+    "bash scripts/test_shiki_control_plane.sh",
+    "bash scripts/test_shiki_run_orchestrator.sh",
+    "Validate Shiki mirror runs the run orchestrator contract test in CI.",
+    "PR evidence includes CCA and MergeGate success."
+  ],
+  "expected_branch": "shiki-plan-run-orchestrator",
+  "expected_pr": null,
+  "ledger_evidence": [
+    "L-0009"
+  ],
+  "status": "review"
+}

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -89,12 +89,19 @@ After `shiki init` has connected the target repo to GitHub, use the control
 commands for durable execution state:
 
 ```bash
+shiki plan guide --prompt "..."
+shiki plan ingest --plan-file PLAN.json
+shiki run --plan P-0001
 shiki goal create --title "..." --outcome "..."
 shiki issue plan --goal-id G-0001 --title "..." --scope "..." --acceptance-check "..."
 shiki lock acquire T-0001
 shiki dispatch check T-0001
 shiki worktree allocate T-0001
+shiki github issue --task-id T-0001
+shiki github pr --task-id T-0001
 shiki repair packet --task-id T-0001 --pr 123 --minimal-change "..." --verification-command "..."
+shiki handoff task T-0001
+shiki handoff repair RP-0001
 shiki task status T-0001 --status done
 shiki goal complete G-0001
 ```

--- a/docs/agents/control-commands.md
+++ b/docs/agents/control-commands.md
@@ -7,6 +7,52 @@ the target does not have a `.shiki` mirror, a git repository, and a GitHub
 
 ## Standard Flow
 
+For non-trivial work, do not start by manually creating each task. First run
+`grill-with-docs`, then persist its settled output as a plan:
+
+```json
+{
+  "title": "Goal title",
+  "outcome": "Observable outcome",
+  "completion_conditions": ["Completion condition"],
+  "non_goals": ["Out of scope"],
+  "required_skills": ["grill-with-docs", "tdd"],
+  "grill_with_docs": {
+    "status": "complete",
+    "source": "CONTEXT.md",
+    "decisions": ["Settled decision"]
+  },
+  "tasks": [
+    {
+      "title": "Vertical slice title",
+      "scope": "Smallest end-to-end slice",
+      "acceptance_checks": ["Public behavior is verified"],
+      "locks": ["path:src/example/*"],
+      "required_skills": ["tdd"]
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+shiki plan ingest --plan-file PLAN.json
+shiki run --plan P-0001
+```
+
+`shiki run` creates the Goal, vertical-slice tasks, Task DAG, lock records, the
+first dispatchable worktree record, run evidence, and ledger entries. It leaves
+dependent or lock-conflicted tasks blocked instead of dispatching them.
+
+For guided setup before the plan exists:
+
+```bash
+shiki plan guide --prompt "user goal"
+```
+
+The lower-level commands remain available for explicit control or repair:
+
 ```bash
 shiki goal create \
   --title "Goal title" \
@@ -28,6 +74,14 @@ shiki dispatch check T-0001
 shiki worktree allocate T-0001
 ```
 
+Create durable GitHub and Codex handoff evidence:
+
+```bash
+shiki github issue --task-id T-0001
+shiki handoff task T-0001
+shiki github pr --task-id T-0001
+```
+
 Codex then implements only the assigned task scope. If CCA rejects the PR, the
 bounded repair loop starts with a repair packet:
 
@@ -38,6 +92,8 @@ shiki repair packet \
   --failing-item "missing verification evidence" \
   --minimal-change "add the requested evidence only" \
   --verification-command "python3 scripts/validate_shiki.py"
+
+shiki handoff repair RP-0001
 ```
 
 When the task is actually accepted, update task state and judge the goal:
@@ -50,12 +106,15 @@ shiki goal complete G-0001
 ## State Files
 
 - `.shiki/goals/*.json` records goals and completion conditions.
+- `.shiki/plans/*.json` records machine-readable `grill-with-docs` outcomes.
 - `.shiki/tasks/*.json` records vertical-slice tasks.
 - `.shiki/dag/*.json` records dependency edges.
 - `.shiki/locks/*.json` records active lock ownership.
 - `.shiki/worktrees/*.json` records assigned work surfaces.
 - `.shiki/repairs/*.json` records bounded repair packets.
 - `.shiki/reports/*.json` records goal completion judgments.
+- `.shiki/runs/*.json` records orchestrator runs.
+- `.shiki/handoffs/*.md` records Codex task and repair handoffs.
 - `.shiki/ledger/*.json` records durable evidence for every transition.
 
 ## Authority Boundary

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -46,6 +46,9 @@ TEMPLATE_PATHS = [
     "scripts/enforce_cca_verdict.py",
     "scripts/mergegate_check.py",
     "scripts/shiki.py",
+    "scripts/test_shiki_init.sh",
+    "scripts/test_shiki_control_plane.sh",
+    "scripts/test_shiki_run_orchestrator.sh",
 ]
 
 DEFAULT_REQUIRED_CHECKS = [
@@ -59,6 +62,7 @@ DEFAULT_CLAUDE_COMMAND_PATH = "~/.claude/commands/shiki.md"
 DEFAULT_CODEX_SKILL_PATH = "~/.codex/skills/shiki/SKILL.md"
 TARGET_STATE_DIRECTORIES = [
     ".shiki/goals",
+    ".shiki/plans",
     ".shiki/tasks",
     ".shiki/dag",
     ".shiki/ledger",
@@ -66,6 +70,8 @@ TARGET_STATE_DIRECTORIES = [
     ".shiki/worktrees",
     ".shiki/repairs",
     ".shiki/reports",
+    ".shiki/runs",
+    ".shiki/handoffs",
 ]
 GITHUB_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -347,6 +353,14 @@ def load_goal(target: Path, goal_id: str) -> dict[str, Any]:
     return read_json(shiki_path(target, "goals", f"{goal_id}.json"))
 
 
+def load_plan(target: Path, plan_id: str) -> dict[str, Any]:
+    return read_json(shiki_path(target, "plans", f"{plan_id}.json"))
+
+
+def load_repair(target: Path, repair_id: str) -> dict[str, Any]:
+    return read_json(shiki_path(target, "repairs", f"{repair_id}.json"))
+
+
 def task_files(target: Path) -> list[Path]:
     directory = shiki_path(target, "tasks")
     if not directory.exists():
@@ -402,6 +416,45 @@ def require_github_first_target(target: Path) -> None:
         raise ShikiError("Shiki control commands require a GitHub origin; run shiki init TARGET --repo OWNER/NAME")
 
 
+def github_repo_from_origin(target: Path) -> str | None:
+    origin = github_origin(target)
+    if not origin:
+        return None
+    match = re.search(r"github\.com[:/]([^/\s]+/[^/\s]+?)(?:\.git)?$", origin)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def parse_github_number(value: str, kind: str) -> int:
+    pattern = rf"/{kind}/([0-9]+)"
+    match = re.search(pattern, value)
+    if not match:
+        raise ShikiError(f"could not parse GitHub {kind} number from: {value}")
+    return int(match.group(1))
+
+
+def require_grilled_plan(plan: dict[str, Any]) -> None:
+    grill = plan.get("grill_with_docs")
+    if not isinstance(grill, dict) or grill.get("status") != "complete":
+        raise ShikiError("plan must include grill_with_docs.status=complete before Shiki can run it")
+    tasks = plan.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        raise ShikiError("plan must include at least one vertical-slice task")
+    required_goal_fields = ["title", "outcome"]
+    for field in required_goal_fields:
+        if not isinstance(plan.get(field), str) or not plan[field].strip():
+            raise ShikiError(f"plan is missing required field: {field}")
+    for index, task in enumerate(tasks, start=1):
+        if not isinstance(task, dict):
+            raise ShikiError(f"plan task {index} must be an object")
+        for field in ("title", "scope", "acceptance_checks"):
+            if field not in task:
+                raise ShikiError(f"plan task {index} is missing required field: {field}")
+        if not isinstance(task["acceptance_checks"], list) or not task["acceptance_checks"]:
+            raise ShikiError(f"plan task {index} must include acceptance_checks")
+
+
 def append_ledger(
     target: Path,
     *,
@@ -426,6 +479,161 @@ def append_ledger(
     }
     write_json(shiki_path(target, "ledger", f"{ledger_id}.json"), payload)
     return ledger_id
+
+
+def register_goal_from_plan(target: Path, plan: dict[str, Any], *, github_issue: int | None = None) -> tuple[str, str]:
+    goal_id = next_control_id(target, "G")
+    goal_file = shiki_path(target, "goals", f"{goal_id}.json")
+    payload = {
+        "id": goal_id,
+        "github_issue": github_issue,
+        "title": plan["title"],
+        "outcome": plan["outcome"],
+        "completion_conditions": plan.get("completion_conditions") or [plan["outcome"]],
+        "non_goals": plan.get("non_goals") or [],
+        "risk_level": plan.get("risk_level", "low"),
+        "required_skills": plan.get("required_skills") or ["grill-with-docs"],
+        "acceptance_evidence": plan.get("acceptance_evidence") or [
+            "GitHub Issue records the goal.",
+            "Task DAG is registered in .shiki/dag.",
+            "CCA verdict and MergeGate evidence are recorded before completion.",
+        ],
+        "grill_with_docs": plan.get("grill_with_docs"),
+        "source_plan": plan.get("id"),
+        "status": "planned",
+        "created_at": utc_now(),
+    }
+    write_json(goal_file, payload)
+    ledger_id = append_ledger(
+        target,
+        goal_id=goal_id,
+        ledger_type="goal-created",
+        summary=f"Goal registered from plan: {plan['title']}",
+        evidence=[str(goal_file.relative_to(target)), f".shiki/plans/{plan.get('id')}.json"],
+    )
+    payload["ledger_evidence"] = [ledger_id]
+    write_json(goal_file, payload)
+    return goal_id, ledger_id
+
+
+def register_task_from_plan(
+    target: Path,
+    *,
+    goal_id: str,
+    task_plan: dict[str, Any],
+    dependencies: list[str],
+) -> tuple[str, str]:
+    task_id = next_control_id(target, "T")
+    branch = task_plan.get("expected_branch") or f"shiki/{task_id.lower()}-{slugify(task_plan['title'])}"
+    ledger_id = append_ledger(
+        target,
+        goal_id=goal_id,
+        task_id=task_id,
+        ledger_type="task-registered",
+        summary=f"Task registered from plan: {task_plan['title']}",
+        evidence=[f".shiki/tasks/{task_id}.json"],
+    )
+    payload = {
+        "id": task_id,
+        "goal_id": goal_id,
+        "github_issue": task_plan.get("github_issue"),
+        "title": task_plan["title"],
+        "scope": task_plan["scope"],
+        "non_goals": task_plan.get("non_goals") or [],
+        "dependencies": dependencies,
+        "locks": task_plan.get("locks") or [],
+        "assigned_runtime": task_plan.get("runtime", "codex"),
+        "risk_level": task_plan.get("risk_level", "low"),
+        "required_skills": task_plan.get("required_skills") or ["tdd"],
+        "acceptance_checks": task_plan["acceptance_checks"],
+        "expected_branch": branch,
+        "expected_pr": task_plan.get("expected_pr"),
+        "ledger_evidence": [ledger_id],
+        "status": "planned",
+    }
+    task_file = shiki_path(target, "tasks", f"{task_id}.json")
+    write_json(task_file, payload)
+    return task_id, ledger_id
+
+
+def update_goal_dag(target: Path, goal_id: str, task_ids: list[str], dependency_edges: list[dict[str, str]]) -> Path:
+    dag_file = shiki_path(target, "dag", f"{goal_id}.json")
+    existing = {"goal_id": goal_id, "nodes": [], "edges": []}
+    if dag_file.exists():
+        existing = read_json(dag_file)
+    nodes = list(dict.fromkeys([*existing.get("nodes", []), *task_ids]))
+    edge_keys = {(edge.get("from"), edge.get("to")) for edge in existing.get("edges", [])}
+    edges = list(existing.get("edges", []))
+    for edge in dependency_edges:
+        key = (edge["from"], edge["to"])
+        if key not in edge_keys:
+            edges.append(edge)
+            edge_keys.add(key)
+    write_json(dag_file, {"goal_id": goal_id, "nodes": nodes, "edges": edges})
+    return dag_file
+
+
+def try_acquire_locks(target: Path, task_id: str) -> tuple[bool, list[str], str | None]:
+    task = load_task(target, task_id)
+    locks = list(task.get("locks", []))
+    conflicts = has_active_lock_conflict(target, task_id, locks)
+    if conflicts:
+        return False, conflicts, None
+    lock_file = shiki_path(target, "locks", f"{task_id}.json")
+    write_json(
+        lock_file,
+        {
+            "task_id": task_id,
+            "goal_id": task["goal_id"],
+            "locks": locks,
+            "state": "active",
+            "owner": "shiki-run",
+            "created_at": utc_now(),
+        },
+    )
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=task_id,
+        ledger_type="lock",
+        summary=f"Locks acquired for {task_id}",
+        evidence=[str(lock_file.relative_to(target))],
+    )
+    task["status"] = "ready"
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{task_id}.json"), task)
+    return True, [], ledger_id
+
+
+def allocate_worktree_record(target: Path, task_id: str) -> tuple[Path, str]:
+    task = load_task(target, task_id)
+    branch = task["expected_branch"]
+    worktree_path = (target.parent / ".worktrees" / slugify(branch)).resolve()
+    record = {
+        "task_id": task_id,
+        "goal_id": task["goal_id"],
+        "branch": branch,
+        "path": str(worktree_path),
+        "runtime": task["assigned_runtime"],
+        "state": "registered",
+        "locks": task.get("locks", []),
+        "created_by": "shiki-run",
+        "created_at": utc_now(),
+        "pr": task.get("expected_pr"),
+    }
+    worktree_file = shiki_path(target, "worktrees", f"{task_id}.json")
+    write_json(worktree_file, record)
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=task_id,
+        ledger_type="handoff",
+        summary=f"Worktree registered for {task_id}",
+        evidence=[str(worktree_file.relative_to(target))],
+    )
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{task_id}.json"), task)
+    return worktree_file, ledger_id
 
 
 def cmd_goal_create(args: argparse.Namespace) -> int:
@@ -463,6 +671,150 @@ def cmd_goal_create(args: argparse.Namespace) -> int:
         evidence=[str(goal_file.relative_to(target))],
     )
     print_json({"goal_id": goal_id, "goal_file": str(goal_file), "ledger_id": ledger_id, "status": "planned"})
+    return 0
+
+
+def cmd_plan_ingest(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+
+    source = Path(args.plan_file).expanduser().resolve()
+    plan = read_json(source)
+    require_grilled_plan(plan)
+
+    plan_id = next_control_id(target, "P")
+    plan["id"] = plan_id
+    plan["status"] = "ingested"
+    plan["source_file"] = str(source)
+    plan["ingested_at"] = utc_now()
+    plan_file = shiki_path(target, "plans", f"{plan_id}.json")
+    write_json(plan_file, plan)
+    print_json({"plan_id": plan_id, "plan_file": str(plan_file), "status": "ingested"})
+    return 0
+
+
+def cmd_plan_guide(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    prompt = args.prompt or "unspecified goal"
+    result = {
+        "target": str(target),
+        "prompt": prompt,
+        "entry_skill": "grill-with-docs",
+        "required_next_steps": [
+            "Run grill-with-docs until terminology, boundaries, risks, and ADR-worthy decisions are settled.",
+            "Write a machine-readable plan JSON with grill_with_docs.status=complete.",
+            "Run shiki plan ingest --plan-file PLAN.json.",
+            "Run shiki run --plan P-0001 to create the Goal, Task DAG, locks, and first dispatchable worktree.",
+        ],
+        "plan_contract": {
+            "required_goal_fields": ["title", "outcome", "grill_with_docs", "tasks"],
+            "required_task_fields": ["title", "scope", "acceptance_checks"],
+        },
+    }
+    print_json(result)
+    return 0
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+
+    if Path(args.plan).expanduser().exists():
+        plan = read_json(Path(args.plan).expanduser().resolve())
+        require_grilled_plan(plan)
+        if "id" not in plan:
+            plan_id = next_control_id(target, "P")
+            plan["id"] = plan_id
+            plan["status"] = "ingested"
+            plan["source_file"] = str(Path(args.plan).expanduser().resolve())
+            plan["ingested_at"] = utc_now()
+            write_json(shiki_path(target, "plans", f"{plan_id}.json"), plan)
+    else:
+        plan = load_plan(target, args.plan)
+        require_grilled_plan(plan)
+
+    goal_id, goal_ledger = register_goal_from_plan(target, plan)
+    task_ids: list[str] = []
+    task_ids_by_title: dict[str, str] = {}
+    dependency_edges: list[dict[str, str]] = []
+
+    for task_plan in plan["tasks"]:
+        dependency_refs = task_plan.get("dependencies") or []
+        dependencies: list[str] = []
+        for dependency in dependency_refs:
+            if dependency in task_ids_by_title:
+                dependencies.append(task_ids_by_title[dependency])
+            elif isinstance(dependency, str) and re.match(r"^T-[0-9]{4,}$", dependency):
+                dependencies.append(dependency)
+            else:
+                raise ShikiError(f"task {task_plan['title']} references unknown dependency: {dependency}")
+
+        task_id, _ = register_task_from_plan(
+            target,
+            goal_id=goal_id,
+            task_plan=task_plan,
+            dependencies=dependencies,
+        )
+        task_ids.append(task_id)
+        task_ids_by_title[task_plan["title"]] = task_id
+        for dependency in dependencies:
+            dependency_edges.append({"from": dependency, "to": task_id, "reason": "declared plan dependency"})
+
+    dag_file = update_goal_dag(target, goal_id, task_ids, dependency_edges)
+
+    dispatchable: list[str] = []
+    blocked: dict[str, list[str]] = {}
+    worktrees: list[str] = []
+    for task_id in task_ids:
+        task = load_task(target, task_id)
+        if task.get("dependencies"):
+            blocked[task_id] = ["dependencies are not complete"]
+            continue
+        lock_ok, lock_blockers, _ = try_acquire_locks(target, task_id)
+        if not lock_ok:
+            blocked[task_id] = lock_blockers
+            continue
+        worktree_file, _ = allocate_worktree_record(target, task_id)
+        dispatchable.append(task_id)
+        worktrees.append(str(worktree_file.relative_to(target)))
+
+    run_id = next_control_id(target, "RUN")
+    run_file = shiki_path(target, "runs", f"{run_id}.json")
+    run_payload = {
+        "id": run_id,
+        "plan_id": plan["id"],
+        "goal_id": goal_id,
+        "task_ids": task_ids,
+        "dispatchable_task_ids": dispatchable,
+        "blocked_task_ids": blocked,
+        "dag": str(dag_file.relative_to(target)),
+        "worktrees": worktrees,
+        "created_at": utc_now(),
+    }
+    write_json(run_file, run_payload)
+    ledger_id = append_ledger(
+        target,
+        goal_id=goal_id,
+        ledger_type="handoff",
+        summary=f"Shiki run {run_id} created {len(task_ids)} task(s) from plan {plan['id']}",
+        evidence=[str(run_file.relative_to(target)), str(dag_file.relative_to(target))],
+    )
+    print_json(
+        {
+            "run_id": run_id,
+            "plan_id": plan["id"],
+            "goal_id": goal_id,
+            "goal_ledger_id": goal_ledger,
+            "task_ids": task_ids,
+            "dispatchable_task_ids": dispatchable,
+            "blocked_task_ids": blocked,
+            "run_file": str(run_file),
+            "ledger_id": ledger_id,
+        }
+    )
     return 0
 
 
@@ -751,6 +1103,224 @@ def cmd_goal_complete(args: argparse.Namespace) -> int:
     write_json(shiki_path(target, "goals", f"{args.goal_id}.json"), goal)
     print_json({"goal_id": args.goal_id, "status": status, "report_file": str(report_file), "ledger_id": ledger_id, "blocking_reasons": blocking})
     return 1 if blocking else 0
+
+
+def github_issue_body(task: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"## Shiki",
+            f"Goal: {task['goal_id']}",
+            f"Task: {task['id']}",
+            "",
+            "## Scope",
+            task["scope"],
+            "",
+            "## Acceptance",
+            *[f"- {check}" for check in task.get("acceptance_checks", [])],
+            "",
+            "## Locks",
+            *[f"- {lock}" for lock in task.get("locks", [])],
+            "",
+            "## Runtime",
+            str(task.get("assigned_runtime", "codex")),
+        ]
+    )
+
+
+def github_pr_body(task: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"## Shiki",
+            f"Goal: {task['goal_id']}",
+            f"Task: {task['id']}",
+            "CCA checklist profile: PR, TDD, V, CCA",
+            "",
+            "## Scope",
+            task["scope"],
+            "",
+            "## Non-goals",
+            *[f"- {item}" for item in task.get("non_goals", [])],
+            "",
+            "## Acceptance",
+            *[f"- {check}" for check in task.get("acceptance_checks", [])],
+            "",
+            "## Evidence",
+            "- python3 scripts/validate_shiki.py",
+            "",
+            "## Ledger evidence",
+            *[f"- {entry}" for entry in task.get("ledger_evidence", [])],
+            "",
+            "## MergeGate",
+            f"- Locks: {', '.join(task.get('locks', [])) or 'none'}",
+            f"- Risk: {task.get('risk_level', 'low')}",
+            "- CCA required: yes",
+        ]
+    )
+
+
+def cmd_github_issue(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    require_tool("gh")
+    task = load_task(target, args.task_id)
+    result = run(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--title",
+            f"{task['id']}: {task['title']}",
+            "--body",
+            github_issue_body(task),
+        ],
+        cwd=target,
+    )
+    url = result.stdout.strip().splitlines()[-1]
+    issue_number = parse_github_number(url, "issues")
+    task["github_issue"] = issue_number
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=task["id"],
+        ledger_type="handoff",
+        summary=f"GitHub Issue #{issue_number} created for {task['id']}",
+        evidence=[url],
+        links=[url],
+    )
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{task['id']}.json"), task)
+    print_json({"task_id": task["id"], "issue": issue_number, "url": url, "ledger_id": ledger_id})
+    return 0
+
+
+def cmd_github_pr(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    require_tool("gh")
+    task = load_task(target, args.task_id)
+    result = run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--base",
+            args.base,
+            "--head",
+            args.head or task["expected_branch"],
+            "--title",
+            f"{task['id']}: {task['title']}",
+            "--body",
+            github_pr_body(task),
+        ],
+        cwd=target,
+    )
+    url = result.stdout.strip().splitlines()[-1]
+    pr_number = parse_github_number(url, "pull")
+    task["expected_pr"] = pr_number
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=task["id"],
+        ledger_type="handoff",
+        summary=f"GitHub PR #{pr_number} created for {task['id']}",
+        evidence=[url],
+        links=[url],
+    )
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    write_json(shiki_path(target, "tasks", f"{task['id']}.json"), task)
+    worktree = worktree_record(target, task["id"])
+    if worktree:
+        worktree["pr"] = pr_number
+        write_json(shiki_path(target, "worktrees", f"{task['id']}.json"), worktree)
+    print_json({"task_id": task["id"], "pr": pr_number, "url": url, "ledger_id": ledger_id})
+    return 0
+
+
+def write_handoff(target: Path, name: str, body: str) -> Path:
+    path = shiki_path(target, "handoffs", name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def cmd_handoff_task(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    task = load_task(target, args.task_id)
+    body = "\n".join(
+        [
+            f"# Codex Task Handoff: {task['id']}",
+            "",
+            f"Goal: {task['goal_id']}",
+            f"Task: {task['id']}",
+            f"Runtime: {task.get('assigned_runtime')}",
+            f"Branch: {task.get('expected_branch')}",
+            "",
+            "## Scope",
+            task["scope"],
+            "",
+            "## Acceptance Checks",
+            *[f"- {check}" for check in task.get("acceptance_checks", [])],
+            "",
+            "## Locks",
+            *[f"- {lock}" for lock in task.get("locks", [])],
+            "",
+            "## Required Skills",
+            *[f"- {skill}" for skill in task.get("required_skills", [])],
+        ]
+    )
+    handoff_file = write_handoff(target, f"{task['id']}-task.md", body + "\n")
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=task["id"],
+        ledger_type="handoff",
+        summary=f"Task handoff written for {task['id']}",
+        evidence=[str(handoff_file.relative_to(target))],
+    )
+    print_json({"task_id": task["id"], "handoff_file": str(handoff_file), "ledger_id": ledger_id})
+    return 0
+
+
+def cmd_handoff_repair(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    repair = load_repair(target, args.repair_id)
+    task = load_task(target, repair["task_id"])
+    body = "\n".join(
+        [
+            f"# Codex Repair Handoff: {repair['repair_id']}",
+            "",
+            f"Goal: {repair['goal_id']}",
+            f"Task: {repair['task_id']}",
+            f"PR: {repair['pr']}",
+            f"Attempt: {repair['attempt']}",
+            f"Required skill: {repair['required_skill']}",
+            "",
+            "## Minimal Required Changes",
+            *[f"- {item}" for item in repair.get("minimal_required_changes", [])],
+            "",
+            "## Prohibited Changes",
+            *[f"- {item}" for item in repair.get("prohibited_changes", [])],
+            "",
+            "## Verification Commands",
+            *[f"- `{command}`" for command in repair.get("verification_commands", [])],
+            "",
+            "## Task Scope",
+            task["scope"],
+        ]
+    )
+    handoff_file = write_handoff(target, f"{repair['repair_id']}-repair.md", body + "\n")
+    ledger_id = append_ledger(
+        target,
+        goal_id=repair["goal_id"],
+        task_id=repair["task_id"],
+        ledger_type="handoff",
+        summary=f"Repair handoff written for {repair['repair_id']}",
+        evidence=[str(handoff_file.relative_to(target))],
+    )
+    print_json({"repair_id": repair["repair_id"], "handoff_file": str(handoff_file), "ledger_id": ledger_id})
+    return 0
 
 
 def cmd_bootstrap_github(args: argparse.Namespace) -> int:
@@ -1086,6 +1656,22 @@ def build_parser() -> argparse.ArgumentParser:
     status = subcommands.add_parser("status", help="Show local Shiki CLI configuration")
     status.set_defaults(func=cmd_status)
 
+    plan = subcommands.add_parser("plan", help="Ingest and guide grill-with-docs plans")
+    plan_subcommands = plan.add_subparsers(dest="plan_command", required=True)
+    plan_ingest = plan_subcommands.add_parser("ingest", help="Persist a grill-with-docs plan as machine-readable Shiki input")
+    plan_ingest.add_argument("--target", default=".", help="Target repository path")
+    plan_ingest.add_argument("--plan-file", required=True, help="JSON plan produced after grill-with-docs")
+    plan_ingest.set_defaults(func=cmd_plan_ingest)
+    plan_guide = plan_subcommands.add_parser("guide", help="Show the user-facing path from a prompt to a runnable plan")
+    plan_guide.add_argument("--target", default=".", help="Target repository path")
+    plan_guide.add_argument("--prompt", help="Goal or task prompt to guide")
+    plan_guide.set_defaults(func=cmd_plan_guide)
+
+    run_command = subcommands.add_parser("run", help="Run an ingested plan through Goal, Task DAG, locks, and dispatch setup")
+    run_command.add_argument("--target", default=".", help="Target repository path")
+    run_command.add_argument("--plan", required=True, help="Plan id like P-0001 or path to a grilled plan JSON")
+    run_command.set_defaults(func=cmd_run)
+
     goal = subcommands.add_parser("goal", help="Manage Shiki goals")
     goal_subcommands = goal.add_subparsers(dest="goal_command", required=True)
     goal_create = goal_subcommands.add_parser("create", help="Register a GitHub-first Shiki goal")
@@ -1167,6 +1753,30 @@ def build_parser() -> argparse.ArgumentParser:
     repair_packet.add_argument("--evidence-required", action="append", default=[])
     repair_packet.add_argument("--stop-condition", default="Stop after this packet is satisfied or after three failed attempts.")
     repair_packet.set_defaults(func=cmd_repair_packet)
+
+    github_control = subcommands.add_parser("github", help="Create GitHub evidence from Shiki state")
+    github_subcommands = github_control.add_subparsers(dest="github_command", required=True)
+    github_issue = github_subcommands.add_parser("issue", help="Create a GitHub issue for a Shiki task")
+    github_issue.add_argument("--target", default=".", help="Target repository path")
+    github_issue.add_argument("--task-id", required=True)
+    github_issue.set_defaults(func=cmd_github_issue)
+    github_pr = github_subcommands.add_parser("pr", help="Create a GitHub PR for a Shiki task")
+    github_pr.add_argument("--target", default=".", help="Target repository path")
+    github_pr.add_argument("--task-id", required=True)
+    github_pr.add_argument("--base", default="main")
+    github_pr.add_argument("--head")
+    github_pr.set_defaults(func=cmd_github_pr)
+
+    handoff = subcommands.add_parser("handoff", help="Write Codex handoff documents from Shiki state")
+    handoff_subcommands = handoff.add_subparsers(dest="handoff_command", required=True)
+    handoff_task = handoff_subcommands.add_parser("task", help="Write a Codex task handoff")
+    handoff_task.add_argument("--target", default=".", help="Target repository path")
+    handoff_task.add_argument("task_id")
+    handoff_task.set_defaults(func=cmd_handoff_task)
+    handoff_repair = handoff_subcommands.add_parser("repair", help="Write a Codex repair handoff")
+    handoff_repair.add_argument("--target", default=".", help="Target repository path")
+    handoff_repair.add_argument("repair_id")
+    handoff_repair.set_defaults(func=cmd_handoff_repair)
 
     task = subcommands.add_parser("task", help="Manage Shiki task state")
     task_subcommands = task.add_subparsers(dest="task_command", required=True)

--- a/scripts/test_shiki_run_orchestrator.sh
+++ b/scripts/test_shiki_run_orchestrator.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/shiki-run-test-$$"
+TARGET="$TMP_ROOT/target"
+FAKE_BIN="$TMP_ROOT/bin"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+json_get() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"
+}
+
+cd "$ROOT"
+
+python3 scripts/validate_shiki.py
+python3 -m py_compile scripts/shiki.py
+python3 scripts/shiki.py --help | grep -E "plan|run|github|handoff" >/dev/null
+
+mkdir -p "$TARGET" "$FAKE_BIN"
+python3 scripts/shiki.py install-target "$TARGET" --local-only >/tmp/shiki-run-install.out
+
+cd "$TARGET"
+git init -b main >/tmp/shiki-run-git-init.out
+git remote add origin https://github.com/example/shiki-run-test.git
+
+cat >"$TMP_ROOT/grilled-plan.json" <<'JSON'
+{
+  "title": "Ship guided onboarding",
+  "outcome": "A user can finish onboarding through the smallest verified workflow",
+  "completion_conditions": [
+    "All generated tasks are done",
+    "CCA and MergeGate evidence exists"
+  ],
+  "non_goals": [
+    "Do not add billing",
+    "Do not bypass GitHub checks"
+  ],
+  "risk_level": "medium",
+  "required_skills": ["grill-with-docs", "to-prd", "to-issues", "tdd"],
+  "grill_with_docs": {
+    "status": "complete",
+    "source": "CONTEXT.md",
+    "decisions": ["Use one vertical slice first"]
+  },
+  "tasks": [
+    {
+      "title": "Create onboarding checklist",
+      "scope": "Add the smallest end-to-end checklist path",
+      "acceptance_checks": ["User can see one onboarding checklist"],
+      "locks": ["path:src/onboarding/*"],
+      "required_skills": ["tdd"]
+    },
+    {
+      "title": "Record onboarding completion",
+      "scope": "Persist completion and expose it in the UI",
+      "acceptance_checks": ["Completion survives reload"],
+      "dependencies": ["Create onboarding checklist"],
+      "locks": ["path:src/onboarding/*"],
+      "required_skills": ["tdd"]
+    }
+  ]
+}
+JSON
+
+if python3 "$ROOT/scripts/shiki.py" plan ingest --target "$TARGET" --plan-file "$TMP_ROOT/ungrilled.json" 2>/tmp/shiki-run-missing.out; then
+  echo "expected missing plan file to fail" >&2
+  exit 1
+fi
+
+python3 "$ROOT/scripts/shiki.py" plan ingest --target "$TARGET" --plan-file "$TMP_ROOT/grilled-plan.json" >/tmp/shiki-plan-ingest.json
+PLAN_ID="$(json_get /tmp/shiki-plan-ingest.json plan_id)"
+test -f "$TARGET/.shiki/plans/$PLAN_ID.json"
+
+python3 "$ROOT/scripts/shiki.py" run --target "$TARGET" --plan "$PLAN_ID" >/tmp/shiki-run.json
+GOAL_ID="$(json_get /tmp/shiki-run.json goal_id)"
+test -f "$TARGET/.shiki/goals/$GOAL_ID.json"
+test -f "$TARGET/.shiki/dag/$GOAL_ID.json"
+test "$(find "$TARGET/.shiki/tasks" -type f -name 'T-*.json' | wc -l | tr -d ' ')" = "2"
+test "$(find "$TARGET/.shiki/locks" -type f -name 'T-*.json' | wc -l | tr -d ' ')" = "1"
+test "$(find "$TARGET/.shiki/worktrees" -type f -name 'T-*.json' | wc -l | tr -d ' ')" = "1"
+
+cat >"$FAKE_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >>"${SHIKI_FAKE_GH_LOG}"
+if [[ "$1 $2" == "issue create" ]]; then
+  echo "https://github.com/example/shiki-run-test/issues/42"
+  exit 0
+fi
+if [[ "$1 $2" == "pr create" ]]; then
+  echo "https://github.com/example/shiki-run-test/pull/77"
+  exit 0
+fi
+echo "fake gh unsupported: $*" >&2
+exit 1
+SH
+chmod +x "$FAKE_BIN/gh"
+export PATH="$FAKE_BIN:$PATH"
+export SHIKI_FAKE_GH_LOG="$TMP_ROOT/gh.log"
+
+FIRST_TASK="$(python3 - "$TARGET" <<'PY'
+import json, pathlib, sys
+tasks = sorted((pathlib.Path(sys.argv[1]) / ".shiki" / "tasks").glob("T-*.json"))
+print(json.loads(tasks[0].read_text())["id"])
+PY
+)"
+
+python3 "$ROOT/scripts/shiki.py" github issue --target "$TARGET" --task-id "$FIRST_TASK" >/tmp/shiki-github-issue.json
+grep "issue create" "$SHIKI_FAKE_GH_LOG" >/dev/null
+
+python3 "$ROOT/scripts/shiki.py" github pr --target "$TARGET" --task-id "$FIRST_TASK" --base main >/tmp/shiki-github-pr.json
+grep "pr create" "$SHIKI_FAKE_GH_LOG" >/dev/null
+
+python3 "$ROOT/scripts/shiki.py" repair packet \
+  --target "$TARGET" \
+  --task-id "$FIRST_TASK" \
+  --pr 77 \
+  --failing-item "CCA evidence missing" \
+  --minimal-change "attach verification output only" \
+  --verification-command "python3 scripts/validate_shiki.py" \
+  >/tmp/shiki-run-repair.json
+REPAIR_ID="$(json_get /tmp/shiki-run-repair.json repair_id)"
+
+python3 "$ROOT/scripts/shiki.py" handoff repair --target "$TARGET" "$REPAIR_ID" >/tmp/shiki-repair-handoff.json
+HANDOFF_FILE="$(json_get /tmp/shiki-repair-handoff.json handoff_file)"
+test -f "$HANDOFF_FILE"
+grep "$REPAIR_ID" "$HANDOFF_FILE" >/dev/null
+
+python3 "$TARGET/scripts/validate_shiki.py"
+
+echo "shiki run orchestrator tests passed"

--- a/scripts/validate_shiki.py
+++ b/scripts/validate_shiki.py
@@ -16,6 +16,8 @@ SHIKI = ROOT / ".shiki"
 TASK_ID = re.compile(r"^T-[0-9]{4,}$")
 GOAL_ID = re.compile(r"^G-[0-9]{4,}$")
 LEDGER_ID = re.compile(r"^L-[0-9]{4,}$")
+PLAN_ID = re.compile(r"^P-[0-9]{4,}$")
+RUN_ID = re.compile(r"^RUN-[0-9]{4,}$")
 
 TASK_REQUIRED = {
     "id",
@@ -34,6 +36,18 @@ TASK_REQUIRED = {
 
 DAG_REQUIRED = {"goal_id", "nodes", "edges"}
 LEDGER_REQUIRED = {"id", "timestamp", "goal_id", "type", "actor", "summary", "evidence"}
+PLAN_REQUIRED = {"id", "title", "outcome", "grill_with_docs", "tasks"}
+RUN_REQUIRED = {
+    "id",
+    "plan_id",
+    "goal_id",
+    "task_ids",
+    "dispatchable_task_ids",
+    "blocked_task_ids",
+    "dag",
+    "worktrees",
+    "created_at",
+}
 
 RUNTIMES = {
     "codex",
@@ -250,6 +264,55 @@ def validate_worktree(path: Path, data: dict[str, Any], known_tasks: set[str]) -
     require_list(path, data, "locks")
 
 
+def validate_plan(path: Path, data: dict[str, Any]) -> None:
+    require_keys(path, data, PLAN_REQUIRED)
+    plan_id = require_string(path, data, "id")
+    if not PLAN_ID.match(plan_id):
+        raise ValidationError(f"{path}: id must match P-0001 style")
+    require_string(path, data, "title")
+    require_string(path, data, "outcome")
+
+    grill = data.get("grill_with_docs")
+    if not isinstance(grill, dict):
+        raise ValidationError(f"{path}: grill_with_docs must be an object")
+    if grill.get("status") != "complete":
+        raise ValidationError(f"{path}: grill_with_docs.status must be complete")
+
+    tasks = require_list(path, data, "tasks", non_empty=True)
+    for index, task in enumerate(tasks, start=1):
+        if not isinstance(task, dict):
+            raise ValidationError(f"{path}: tasks[{index}] must be an object")
+        for key in ("title", "scope", "acceptance_checks"):
+            if key not in task:
+                raise ValidationError(f"{path}: tasks[{index}] missing {key}")
+        if not isinstance(task.get("acceptance_checks"), list) or not task["acceptance_checks"]:
+            raise ValidationError(f"{path}: tasks[{index}].acceptance_checks must not be empty")
+
+
+def validate_run(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
+    require_keys(path, data, RUN_REQUIRED)
+    run_id = require_string(path, data, "id")
+    if not RUN_ID.match(run_id):
+        raise ValidationError(f"{path}: id must match RUN-0001 style")
+    plan_id = require_string(path, data, "plan_id")
+    if not PLAN_ID.match(plan_id):
+        raise ValidationError(f"{path}: plan_id must match P-0001 style")
+    goal_id = require_string(path, data, "goal_id")
+    if not GOAL_ID.match(goal_id):
+        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    for key in ("task_ids", "dispatchable_task_ids"):
+        for task_id in require_list(path, data, key):
+            if not isinstance(task_id, str) or not TASK_ID.match(task_id):
+                raise ValidationError(f"{path}: {key} must contain T-0001 style ids")
+            if known_tasks and task_id not in known_tasks:
+                raise ValidationError(f"{path}: {key} references unknown task {task_id}")
+    if not isinstance(data.get("blocked_task_ids"), dict):
+        raise ValidationError(f"{path}: blocked_task_ids must be an object")
+    require_string(path, data, "dag")
+    require_string(path, data, "created_at")
+    require_list(path, data, "worktrees")
+
+
 def json_files(directory: Path) -> list[Path]:
     if not directory.exists():
         return []
@@ -287,6 +350,12 @@ def main() -> int:
                 raise ValidationError(f"{dag_path}: DAG must be a JSON object")
             validate_dag(dag_path, data, known_tasks)
 
+        for plan_path in json_files(SHIKI / "plans"):
+            data = load_json(plan_path)
+            if not isinstance(data, dict):
+                raise ValidationError(f"{plan_path}: plan must be a JSON object")
+            validate_plan(plan_path, data)
+
         for ledger_path in json_files(SHIKI / "ledger"):
             data = load_json(ledger_path)
             if not isinstance(data, dict):
@@ -298,6 +367,12 @@ def main() -> int:
             if not isinstance(data, dict):
                 raise ValidationError(f"{worktree_path}: worktree record must be a JSON object")
             validate_worktree(worktree_path, data, known_tasks)
+
+        for run_path in json_files(SHIKI / "runs"):
+            data = load_json(run_path)
+            if not isinstance(data, dict):
+                raise ValidationError(f"{run_path}: run must be a JSON object")
+            validate_run(run_path, data, known_tasks)
 
     except ValidationError as error:
         errors.append(str(error))


### PR DESCRIPTION
## Shiki
Goal: G-0001
Task: T-0008
CCA checklist profile: PR, TDD, V, CCA

## Scope
Add the orchestration layer that turns a completed grill-with-docs plan into durable Shiki execution state. This includes plan ingestion, guided user prompting, shiki run orchestration, GitHub issue/PR evidence creation, and Codex task/repair handoff generation.

## Non-goals
- Do not bypass branch protection.
- Do not require non-standard Python dependencies.
- Do not create real GitHub issues or PRs in local tests.
- Do not implement an always-on daemon or background service in this slice.

## Acceptance
- shiki plan guide tells the user/agent how to proceed from a prompt to a grilled plan.
- shiki plan ingest persists only plans with grill_with_docs.status=complete.
- shiki run creates the Goal, tasks, Task DAG, locks, first dispatchable worktree, run record, and ledger evidence from the plan.
- shiki github issue and shiki github pr create durable GitHub evidence from task state.
- shiki handoff task and shiki handoff repair generate Codex handoff documents.
- scripts/validate_shiki.py validates plan and run artifacts.
- CI runs scripts/test_shiki_run_orchestrator.sh.

## Evidence
- python3 scripts/validate_shiki.py
- python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py
- bash scripts/test_shiki_init.sh
- bash scripts/test_shiki_control_plane.sh
- bash scripts/test_shiki_run_orchestrator.sh

## Ledger evidence
- L-0009: task registration evidence for T-0008.

## MergeGate
- Locks: path:scripts/shiki.py, path:scripts/validate_shiki.py, path:scripts/test_shiki_run_orchestrator.sh, path:.github/workflows/shiki-validate.yml, path:.claude/commands/shiki.md, path:.codex/skills/shiki/SKILL.md, path:docs/agents/bootstrap-command.md, path:docs/agents/control-commands.md, path:.shiki/schemas/plan.schema.json, path:.shiki/schemas/run.schema.json, path:.shiki/tasks/T-0008.json, path:.shiki/ledger/L-0009.json
- Risk: medium
- CCA required: yes
- Merge only after required checks pass.