### PR TITLE
feat: add Shiki daemon and runner automation

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -31,6 +31,8 @@ shiki init . --repo OWNER/NAME
 - Treat Codex as implementer, CCA as completion judge, and MergeGate as merge authorization.
 - For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.
 - After `grill-with-docs` is settled, prefer `shiki plan ingest` and `shiki run` over manually calling each lower-level command.
+- For unattended execution, queue settled plans with `shiki daemon enqueue-plan` and process them with `shiki daemon run`.
+- For headless runner integration, use `shiki runner next` and `shiki runner execute` so execution evidence lands in `.shiki/runner` and the Ledger.
 - Register durable state through Shiki commands: `goal create`, `issue plan`, `lock acquire`, `dispatch check`, `worktree allocate`, `repair packet`, `task status`, and `goal complete`.
 - Use `shiki github issue`, `shiki github pr`, and `shiki handoff` to create durable GitHub and Codex evidence instead of free-form handoff text.
 - Do not claim completion from local work alone. Completion requires PR evidence, CCA, and MergeGate.

--- a/.codex/skills/shiki/SKILL.md
+++ b/.codex/skills/shiki/SKILL.md
@@ -39,6 +39,8 @@ shiki init . --repo OWNER/NAME
 
 - For non-trivial goals, enter through `grill-with-docs`.
 - Convert the settled `grill-with-docs` result into a machine-readable plan and run it with `shiki plan ingest` followed by `shiki run`.
+- For unattended execution, queue the plan with `shiki daemon enqueue-plan` and process it with `shiki daemon run`.
+- For headless runtime integration, use `shiki runner next` and `shiki runner execute` to pick up ready tasks and record execution evidence.
 - Use Context and Impact before implementation.
 - Keep tasks as vertical slices with explicit locks and verification.
 - Use TDD for implementation work when behavior changes.
@@ -55,6 +57,13 @@ shiki init . --repo OWNER/NAME
 - `shiki plan guide --prompt "..."`
 - `shiki plan ingest --plan-file PLAN.json`
 - `shiki run --plan P-0001`
+- `shiki daemon enqueue-plan --plan-file PLAN.json`
+- `shiki daemon run --once`
+- `shiki runner next`
+- `shiki runner execute --task-id T-0001 --command "..."`
+- `shiki smoke live --plan-file PLAN.json --dry-run`
+- `shiki smoke live --plan-file PLAN.json --execute-github`
+- `shiki smoke live --plan-file PLAN.json --execute-github --push-branch`
 - `shiki goal create --title ... --outcome ...`
 - `shiki issue plan --goal-id G-0001 --title ... --scope ... --acceptance-check ...`
 - `shiki lock acquire T-0001`

--- a/.github/workflows/shiki-orchestrator.yml
+++ b/.github/workflows/shiki-orchestrator.yml
@@ -1,0 +1,79 @@
+name: Shiki Orchestrator
+
+on:
+  workflow_dispatch:
+    inputs:
+      plan_path:
+        description: "Path to a grilled Shiki plan JSON in the repository"
+        required: true
+        default: ".shiki/inbox/plan.json"
+      mode:
+        description: "dry-run or execute-github"
+        required: true
+        default: "dry-run"
+        type: choice
+        options:
+          - dry-run
+          - execute-github
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  shiki-run:
+    name: Shiki orchestrator run
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.comment.body, '/shiki')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve command
+        id: command
+        shell: bash
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "plan_path=${{ inputs.plan_path }}" >> "$GITHUB_OUTPUT"
+            echo "mode=${{ inputs.mode }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          plan_path="$(printf '%s\n' "$COMMENT_BODY" | awk '/^plan:/{print $2; exit}')"
+          mode="$(printf '%s\n' "$COMMENT_BODY" | awk '/^mode:/{print $2; exit}')"
+          echo "plan_path=${plan_path:-.shiki/inbox/plan.json}" >> "$GITHUB_OUTPUT"
+          echo "mode=${mode:-dry-run}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Shiki plan
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.command.outputs.mode }}" == "execute-github" ]]; then
+            python3 scripts/shiki.py smoke live --target . --plan-file "${{ steps.command.outputs.plan_path }}" --execute-github
+          else
+            python3 scripts/shiki.py smoke live --target . --plan-file "${{ steps.command.outputs.plan_path }}" --dry-run
+          fi
+
+      - name: Commit Shiki evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No Shiki evidence changes to commit."
+            exit 0
+          fi
+          git config user.name "shiki-orchestrator"
+          git config user.email "shiki-orchestrator@users.noreply.github.com"
+          git add .shiki
+          git commit -m "shiki: record orchestrator evidence"
+          git push

--- a/.github/workflows/shiki-validate.yml
+++ b/.github/workflows/shiki-validate.yml
@@ -32,3 +32,6 @@ jobs:
 
       - name: Run Shiki run orchestrator contract test
         run: bash scripts/test_shiki_run_orchestrator.sh
+
+      - name: Run Shiki daemon and runner contract test
+        run: bash scripts/test_shiki_daemon_runner.sh

--- a/.shiki/ledger/L-0011.json
+++ b/.shiki/ledger/L-0011.json
@@ -1,0 +1,16 @@
+{
+  "id": "L-0011",
+  "timestamp": "2026-05-29T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0009",
+  "type": "task-registered",
+  "actor": "codex-front",
+  "summary": "Registered Shiki daemon, runner, live smoke, and GitHub orchestrator automation implementation with TDD evidence requirements.",
+  "evidence": [
+    ".shiki/tasks/T-0009.json",
+    "scripts/test_shiki_daemon_runner.sh",
+    "scripts/shiki.py",
+    ".github/workflows/shiki-orchestrator.yml"
+  ],
+  "links": []
+}

--- a/.shiki/ledger/L-0012.json
+++ b/.shiki/ledger/L-0012.json
@@ -1,0 +1,19 @@
+{
+  "id": "L-0012",
+  "timestamp": "2026-05-29T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0008",
+  "type": "completion",
+  "actor": "codex-front",
+  "summary": "Marked T-0008 complete after PR #15 merged with Validate, CCA, and MergeGate checks passing.",
+  "evidence": [
+    "PR #15 merged: https://github.com/mizutani-140/shiki/pull/15",
+    "Merge commit: 63ed49df0a7e779ea03d6c9ce871f2c570cc1e45",
+    "CCA verdict: success",
+    "MergeGate policy check: success",
+    "Validate Shiki mirror: success"
+  ],
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/15"
+  ]
+}

--- a/.shiki/ledger/L-0013.json
+++ b/.shiki/ledger/L-0013.json
@@ -1,0 +1,23 @@
+{
+  "id": "L-0013",
+  "timestamp": "2026-05-29T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0009",
+  "type": "check",
+  "actor": "codex-front",
+  "summary": "Recorded PR #16 evidence for Shiki daemon, runner, live smoke, and GitHub orchestrator automation.",
+  "evidence": [
+    "PR #16: https://github.com/mizutani-140/shiki/pull/16",
+    "Validate Shiki mirror must run scripts/test_shiki_daemon_runner.sh on the PR head SHA.",
+    "Local verification: python3 scripts/validate_shiki.py",
+    "Local verification: python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py",
+    "Local verification: bash scripts/test_shiki_init.sh",
+    "Local verification: bash scripts/test_shiki_control_plane.sh",
+    "Local verification: bash scripts/test_shiki_run_orchestrator.sh",
+    "Local verification: bash scripts/test_shiki_daemon_runner.sh",
+    "Local verification: Ruby YAML load for .github/workflows/*.yml"
+  ],
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/16"
+  ]
+}

--- a/.shiki/schemas/inbox.schema.json
+++ b/.shiki/schemas/inbox.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiki.local/schemas/inbox.schema.json",
+  "title": "Shiki Inbox Item",
+  "type": "object",
+  "required": ["id", "type", "state", "created_at"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^INBOX-[0-9]{4,}$" },
+    "type": { "enum": ["plan"] },
+    "state": { "enum": ["pending", "processed", "failed"] },
+    "source_file": { "type": "string" },
+    "created_at": { "type": "string", "minLength": 1 },
+    "processed_at": { "type": "string" },
+    "plan": { "type": "object" },
+    "result": { "type": "object" }
+  },
+  "additionalProperties": true
+}

--- a/.shiki/schemas/runner-record.schema.json
+++ b/.shiki/schemas/runner-record.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiki.local/schemas/runner-record.schema.json",
+  "title": "Shiki Runner Record",
+  "type": "object",
+  "required": ["id", "task_id", "goal_id", "command", "returncode", "stdout", "stderr", "created_at"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^EXEC-[0-9]{4,}$" },
+    "task_id": { "type": "string", "pattern": "^T-[0-9]{4,}$" },
+    "goal_id": { "type": "string", "pattern": "^G-[0-9]{4,}$" },
+    "command": { "type": "string", "minLength": 1 },
+    "returncode": { "type": "integer" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "created_at": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": true
+}

--- a/.shiki/schemas/smoke.schema.json
+++ b/.shiki/schemas/smoke.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiki.local/schemas/smoke.schema.json",
+  "title": "Shiki Smoke Record",
+  "type": "object",
+  "required": ["id", "repo", "dry_run", "execute_github", "created_at"],
+  "properties": {
+    "id": { "type": "string", "pattern": "^SMOKE-[0-9]{4,}$" },
+    "repo": { "type": "string", "minLength": 1 },
+    "dry_run": { "type": "boolean" },
+    "execute_github": { "type": "boolean" },
+    "result": { "type": "object" },
+    "github": { "type": "object" },
+    "created_at": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": true
+}

--- a/.shiki/tasks/T-0008.json
+++ b/.shiki/tasks/T-0008.json
@@ -47,7 +47,8 @@
   "expected_pr": 15,
   "ledger_evidence": [
     "L-0009",
-    "L-0010"
+    "L-0010",
+    "L-0012"
   ],
-  "status": "review"
+  "status": "done"
 }

--- a/.shiki/tasks/T-0009.json
+++ b/.shiki/tasks/T-0009.json
@@ -1,0 +1,56 @@
+{
+  "id": "T-0009",
+  "goal_id": "G-0001",
+  "github_issue": null,
+  "title": "Add daemon, runner, live smoke, and GitHub orchestrator automation",
+  "scope": "Implement the remaining automation layer so users can queue grill-with-docs plans for background processing, run headless task commands with ledger evidence, smoke-test a real GitHub-backed target, and trigger Shiki orchestration from GitHub Actions.",
+  "non_goals": [
+    "Do not bypass branch protection.",
+    "Do not create real GitHub issues or PRs in local tests.",
+    "Do not require non-standard Python dependencies.",
+    "Do not hard-code Codex or Hermes as the only runner runtime."
+  ],
+  "dependencies": [
+    "T-0008"
+  ],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/validate_shiki.py",
+    "path:scripts/test_shiki_daemon_runner.sh",
+    "path:.github/workflows/shiki-validate.yml",
+    "path:.github/workflows/shiki-orchestrator.yml",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:docs/agents/control-commands.md",
+    "path:.shiki/schemas/inbox.schema.json",
+    "path:.shiki/schemas/runner-record.schema.json",
+    "path:.shiki/schemas/smoke.schema.json",
+    "path:.shiki/tasks/T-0008.json",
+    "path:.shiki/tasks/T-0009.json",
+    "path:.shiki/ledger/L-0011.json",
+    "path:.shiki/ledger/L-0012.json"
+  ],
+  "assigned_runtime": "codex-front",
+  "risk_level": "medium",
+  "required_skills": [
+    "shiki",
+    "tdd"
+  ],
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py",
+    "python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py",
+    "bash scripts/test_shiki_init.sh",
+    "bash scripts/test_shiki_control_plane.sh",
+    "bash scripts/test_shiki_run_orchestrator.sh",
+    "bash scripts/test_shiki_daemon_runner.sh",
+    "Validate Shiki mirror runs daemon and runner contract tests in CI.",
+    "PR evidence includes CCA and MergeGate success."
+  ],
+  "expected_branch": "shiki-daemon-runner-automation",
+  "expected_pr": null,
+  "ledger_evidence": [
+    "L-0011"
+  ],
+  "status": "review"
+}

--- a/.shiki/tasks/T-0009.json
+++ b/.shiki/tasks/T-0009.json
@@ -29,7 +29,8 @@
     "path:.shiki/tasks/T-0008.json",
     "path:.shiki/tasks/T-0009.json",
     "path:.shiki/ledger/L-0011.json",
-    "path:.shiki/ledger/L-0012.json"
+    "path:.shiki/ledger/L-0012.json",
+    "path:.shiki/ledger/L-0013.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -48,9 +49,10 @@
     "PR evidence includes CCA and MergeGate success."
   ],
   "expected_branch": "shiki-daemon-runner-automation",
-  "expected_pr": null,
+  "expected_pr": 16,
   "ledger_evidence": [
-    "L-0011"
+    "L-0011",
+    "L-0013"
   ],
   "status": "review"
 }

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -92,6 +92,13 @@ commands for durable execution state:
 shiki plan guide --prompt "..."
 shiki plan ingest --plan-file PLAN.json
 shiki run --plan P-0001
+shiki daemon enqueue-plan --plan-file PLAN.json
+shiki daemon run --once
+shiki runner next
+shiki runner execute --task-id T-0001 --command "..."
+shiki smoke live --plan-file PLAN.json --dry-run
+shiki smoke live --plan-file PLAN.json --execute-github
+shiki smoke live --plan-file PLAN.json --execute-github --push-branch
 shiki goal create --title "..." --outcome "..."
 shiki issue plan --goal-id G-0001 --title "..." --scope "..." --acceptance-check "..."
 shiki lock acquire T-0001

--- a/docs/agents/control-commands.md
+++ b/docs/agents/control-commands.md
@@ -53,6 +53,53 @@ shiki plan guide --prompt "user goal"
 
 The lower-level commands remain available for explicit control or repair:
 
+## Daemon And Runner
+
+For unattended execution on a local or self-hosted machine, queue a settled plan
+and process it from the inbox:
+
+```bash
+shiki daemon enqueue-plan --plan-file PLAN.json
+shiki daemon run --once
+```
+
+Omit `--once` when a supervisor such as `launchd`, `systemd`, or a long-running
+terminal session should keep polling `.shiki/inbox`.
+
+Headless runners pick up dispatchable tasks and record command evidence:
+
+```bash
+shiki runner next
+shiki runner execute --task-id T-0001 --command "your-agent-command"
+```
+
+Use the runner command as the adapter boundary for Codex headless, Hermes
+Runner, or another runtime. The command is intentionally explicit: Shiki records
+the task, command, stdout, stderr, return code, and Ledger evidence, but the
+runtime command itself is supplied by the operator.
+
+## Live Smoke
+
+Before trusting a target repository, run:
+
+```bash
+shiki smoke live --plan-file PLAN.json --dry-run
+```
+
+When you intentionally want to create GitHub evidence:
+
+```bash
+shiki smoke live --plan-file PLAN.json --execute-github
+```
+
+The live smoke verifies GitHub auth, repository visibility, plan validity, Shiki
+run orchestration, and optional GitHub Issue / PR evidence creation.
+For a real PR smoke where the branch does not already exist, use:
+
+```bash
+shiki smoke live --plan-file PLAN.json --execute-github --push-branch
+```
+
 ```bash
 shiki goal create \
   --title "Goal title" \
@@ -115,6 +162,9 @@ shiki goal complete G-0001
 - `.shiki/reports/*.json` records goal completion judgments.
 - `.shiki/runs/*.json` records orchestrator runs.
 - `.shiki/handoffs/*.md` records Codex task and repair handoffs.
+- `.shiki/inbox/*.json` records queued daemon work.
+- `.shiki/runner/*.json` records headless runner command evidence.
+- `.shiki/smoke/*.json` records live smoke results.
 - `.shiki/ledger/*.json` records durable evidence for every transition.
 
 ## Authority Boundary

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -15,6 +15,7 @@ from typing import Any
 import shutil
 import subprocess
 import sys
+import time
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -49,6 +50,7 @@ TEMPLATE_PATHS = [
     "scripts/test_shiki_init.sh",
     "scripts/test_shiki_control_plane.sh",
     "scripts/test_shiki_run_orchestrator.sh",
+    "scripts/test_shiki_daemon_runner.sh",
 ]
 
 DEFAULT_REQUIRED_CHECKS = [
@@ -71,7 +73,10 @@ TARGET_STATE_DIRECTORIES = [
     ".shiki/repairs",
     ".shiki/reports",
     ".shiki/runs",
+    ".shiki/inbox",
     ".shiki/handoffs",
+    ".shiki/runner",
+    ".shiki/smoke",
 ]
 GITHUB_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -636,6 +641,93 @@ def allocate_worktree_record(target: Path, task_id: str) -> tuple[Path, str]:
     return worktree_file, ledger_id
 
 
+def orchestrate_plan(target: Path, plan: dict[str, Any]) -> dict[str, Any]:
+    require_grilled_plan(plan)
+    if "id" not in plan:
+        plan["id"] = next_control_id(target, "P")
+        plan["status"] = "ingested"
+        plan["ingested_at"] = utc_now()
+        write_json(shiki_path(target, "plans", f"{plan['id']}.json"), plan)
+
+    goal_id, goal_ledger = register_goal_from_plan(target, plan)
+    task_ids: list[str] = []
+    task_ids_by_title: dict[str, str] = {}
+    dependency_edges: list[dict[str, str]] = []
+
+    for task_plan in plan["tasks"]:
+        dependency_refs = task_plan.get("dependencies") or []
+        dependencies: list[str] = []
+        for dependency in dependency_refs:
+            if dependency in task_ids_by_title:
+                dependencies.append(task_ids_by_title[dependency])
+            elif isinstance(dependency, str) and re.match(r"^T-[0-9]{4,}$", dependency):
+                dependencies.append(dependency)
+            else:
+                raise ShikiError(f"task {task_plan['title']} references unknown dependency: {dependency}")
+
+        task_id, _ = register_task_from_plan(
+            target,
+            goal_id=goal_id,
+            task_plan=task_plan,
+            dependencies=dependencies,
+        )
+        task_ids.append(task_id)
+        task_ids_by_title[task_plan["title"]] = task_id
+        for dependency in dependencies:
+            dependency_edges.append({"from": dependency, "to": task_id, "reason": "declared plan dependency"})
+
+    dag_file = update_goal_dag(target, goal_id, task_ids, dependency_edges)
+
+    dispatchable: list[str] = []
+    blocked: dict[str, list[str]] = {}
+    worktrees: list[str] = []
+    for task_id in task_ids:
+        task = load_task(target, task_id)
+        if task.get("dependencies"):
+            blocked[task_id] = ["dependencies are not complete"]
+            continue
+        lock_ok, lock_blockers, _ = try_acquire_locks(target, task_id)
+        if not lock_ok:
+            blocked[task_id] = lock_blockers
+            continue
+        worktree_file, _ = allocate_worktree_record(target, task_id)
+        dispatchable.append(task_id)
+        worktrees.append(str(worktree_file.relative_to(target)))
+
+    run_id = next_control_id(target, "RUN")
+    run_file = shiki_path(target, "runs", f"{run_id}.json")
+    run_payload = {
+        "id": run_id,
+        "plan_id": plan["id"],
+        "goal_id": goal_id,
+        "task_ids": task_ids,
+        "dispatchable_task_ids": dispatchable,
+        "blocked_task_ids": blocked,
+        "dag": str(dag_file.relative_to(target)),
+        "worktrees": worktrees,
+        "created_at": utc_now(),
+    }
+    write_json(run_file, run_payload)
+    ledger_id = append_ledger(
+        target,
+        goal_id=goal_id,
+        ledger_type="handoff",
+        summary=f"Shiki run {run_id} created {len(task_ids)} task(s) from plan {plan['id']}",
+        evidence=[str(run_file.relative_to(target)), str(dag_file.relative_to(target))],
+    )
+    return {
+        "run_id": run_id,
+        "plan_id": plan["id"],
+        "goal_id": goal_id,
+        "goal_ledger_id": goal_ledger,
+        "task_ids": task_ids,
+        "dispatchable_task_ids": dispatchable,
+        "blocked_task_ids": blocked,
+        "run_file": str(run_file),
+        "ledger_id": ledger_id,
+    }
+
+
 def cmd_goal_create(args: argparse.Namespace) -> int:
     target = target_path(args.target)
     require_github_first_target(target)
@@ -734,87 +826,8 @@ def cmd_run(args: argparse.Namespace) -> int:
             write_json(shiki_path(target, "plans", f"{plan_id}.json"), plan)
     else:
         plan = load_plan(target, args.plan)
-        require_grilled_plan(plan)
 
-    goal_id, goal_ledger = register_goal_from_plan(target, plan)
-    task_ids: list[str] = []
-    task_ids_by_title: dict[str, str] = {}
-    dependency_edges: list[dict[str, str]] = []
-
-    for task_plan in plan["tasks"]:
-        dependency_refs = task_plan.get("dependencies") or []
-        dependencies: list[str] = []
-        for dependency in dependency_refs:
-            if dependency in task_ids_by_title:
-                dependencies.append(task_ids_by_title[dependency])
-            elif isinstance(dependency, str) and re.match(r"^T-[0-9]{4,}$", dependency):
-                dependencies.append(dependency)
-            else:
-                raise ShikiError(f"task {task_plan['title']} references unknown dependency: {dependency}")
-
-        task_id, _ = register_task_from_plan(
-            target,
-            goal_id=goal_id,
-            task_plan=task_plan,
-            dependencies=dependencies,
-        )
-        task_ids.append(task_id)
-        task_ids_by_title[task_plan["title"]] = task_id
-        for dependency in dependencies:
-            dependency_edges.append({"from": dependency, "to": task_id, "reason": "declared plan dependency"})
-
-    dag_file = update_goal_dag(target, goal_id, task_ids, dependency_edges)
-
-    dispatchable: list[str] = []
-    blocked: dict[str, list[str]] = {}
-    worktrees: list[str] = []
-    for task_id in task_ids:
-        task = load_task(target, task_id)
-        if task.get("dependencies"):
-            blocked[task_id] = ["dependencies are not complete"]
-            continue
-        lock_ok, lock_blockers, _ = try_acquire_locks(target, task_id)
-        if not lock_ok:
-            blocked[task_id] = lock_blockers
-            continue
-        worktree_file, _ = allocate_worktree_record(target, task_id)
-        dispatchable.append(task_id)
-        worktrees.append(str(worktree_file.relative_to(target)))
-
-    run_id = next_control_id(target, "RUN")
-    run_file = shiki_path(target, "runs", f"{run_id}.json")
-    run_payload = {
-        "id": run_id,
-        "plan_id": plan["id"],
-        "goal_id": goal_id,
-        "task_ids": task_ids,
-        "dispatchable_task_ids": dispatchable,
-        "blocked_task_ids": blocked,
-        "dag": str(dag_file.relative_to(target)),
-        "worktrees": worktrees,
-        "created_at": utc_now(),
-    }
-    write_json(run_file, run_payload)
-    ledger_id = append_ledger(
-        target,
-        goal_id=goal_id,
-        ledger_type="handoff",
-        summary=f"Shiki run {run_id} created {len(task_ids)} task(s) from plan {plan['id']}",
-        evidence=[str(run_file.relative_to(target)), str(dag_file.relative_to(target))],
-    )
-    print_json(
-        {
-            "run_id": run_id,
-            "plan_id": plan["id"],
-            "goal_id": goal_id,
-            "goal_ledger_id": goal_ledger,
-            "task_ids": task_ids,
-            "dispatchable_task_ids": dispatchable,
-            "blocked_task_ids": blocked,
-            "run_file": str(run_file),
-            "ledger_id": ledger_id,
-        }
-    )
+    print_json(orchestrate_plan(target, plan))
     return 0
 
 
@@ -1158,11 +1171,9 @@ def github_pr_body(task: dict[str, Any]) -> str:
     )
 
 
-def cmd_github_issue(args: argparse.Namespace) -> int:
-    target = target_path(args.target)
-    require_github_first_target(target)
+def create_github_issue_for_task(target: Path, task_id: str) -> dict[str, Any]:
     require_tool("gh")
-    task = load_task(target, args.task_id)
+    task = load_task(target, task_id)
     result = run(
         [
             "gh",
@@ -1189,24 +1200,28 @@ def cmd_github_issue(args: argparse.Namespace) -> int:
     )
     task.setdefault("ledger_evidence", []).append(ledger_id)
     write_json(shiki_path(target, "tasks", f"{task['id']}.json"), task)
-    print_json({"task_id": task["id"], "issue": issue_number, "url": url, "ledger_id": ledger_id})
+    return {"task_id": task["id"], "issue": issue_number, "url": url, "ledger_id": ledger_id}
+
+
+def cmd_github_issue(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    print_json(create_github_issue_for_task(target, args.task_id))
     return 0
 
 
-def cmd_github_pr(args: argparse.Namespace) -> int:
-    target = target_path(args.target)
-    require_github_first_target(target)
+def create_github_pr_for_task(target: Path, task_id: str, *, base: str, head: str | None = None) -> dict[str, Any]:
     require_tool("gh")
-    task = load_task(target, args.task_id)
+    task = load_task(target, task_id)
     result = run(
         [
             "gh",
             "pr",
             "create",
             "--base",
-            args.base,
+            base,
             "--head",
-            args.head or task["expected_branch"],
+            head or task["expected_branch"],
             "--title",
             f"{task['id']}: {task['title']}",
             "--body",
@@ -1232,7 +1247,13 @@ def cmd_github_pr(args: argparse.Namespace) -> int:
     if worktree:
         worktree["pr"] = pr_number
         write_json(shiki_path(target, "worktrees", f"{task['id']}.json"), worktree)
-    print_json({"task_id": task["id"], "pr": pr_number, "url": url, "ledger_id": ledger_id})
+    return {"task_id": task["id"], "pr": pr_number, "url": url, "ledger_id": ledger_id}
+
+
+def cmd_github_pr(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    print_json(create_github_pr_for_task(target, args.task_id, base=args.base, head=args.head))
     return 0
 
 
@@ -1320,6 +1341,201 @@ def cmd_handoff_repair(args: argparse.Namespace) -> int:
         evidence=[str(handoff_file.relative_to(target))],
     )
     print_json({"repair_id": repair["repair_id"], "handoff_file": str(handoff_file), "ledger_id": ledger_id})
+    return 0
+
+
+def cmd_daemon_enqueue_plan(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    source = Path(args.plan_file).expanduser().resolve()
+    plan = read_json(source)
+    require_grilled_plan(plan)
+    inbox_id = next_control_id(target, "INBOX")
+    inbox_file = shiki_path(target, "inbox", f"{inbox_id}.json")
+    write_json(
+        inbox_file,
+        {
+            "id": inbox_id,
+            "type": "plan",
+            "state": "pending",
+            "source_file": str(source),
+            "plan": plan,
+            "created_at": utc_now(),
+        },
+    )
+    print_json({"inbox_id": inbox_id, "inbox_file": str(inbox_file), "state": "pending"})
+    return 0
+
+
+def process_inbox_item(target: Path, path: Path) -> dict[str, Any]:
+    item = read_json(path)
+    if item.get("state") != "pending":
+        return {"inbox_id": item.get("id"), "state": "skipped"}
+    if item.get("type") != "plan":
+        raise ShikiError(f"unsupported inbox item type: {item.get('type')}")
+    result = orchestrate_plan(target, item["plan"])
+    archive = shiki_path(target, "inbox", "processed", path.name)
+    archive.parent.mkdir(parents=True, exist_ok=True)
+    item.update({"state": "processed", "processed_at": utc_now(), "result": result})
+    write_json(archive, item)
+    path.unlink()
+    return result
+
+
+def cmd_daemon_run(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    processed: list[dict[str, Any]] = []
+
+    while True:
+        pending = sorted(
+            path
+            for path in shiki_path(target, "inbox").glob("*.json")
+            if path.is_file()
+        )
+        for path in pending:
+            processed.append(process_inbox_item(target, path))
+            if args.once:
+                result = processed[-1]
+                result["processed_count"] = len(processed)
+                print_json(result)
+                return 0
+        if args.once:
+            print_json({"processed_count": 0, "state": "idle"})
+            return 0
+        time.sleep(args.interval)
+
+
+def dispatchable_task_ids(target: Path) -> list[str]:
+    ids: list[str] = []
+    for path in task_files(target):
+        task = read_json(path)
+        if task.get("status") != "ready":
+            continue
+        if worktree_record(target, task["id"]) is None:
+            continue
+        if task.get("dependencies"):
+            dependencies = [load_task(target, dep) for dep in task.get("dependencies", [])]
+            if any(dep.get("status") != "done" for dep in dependencies):
+                continue
+        ids.append(task["id"])
+    return ids
+
+
+def cmd_runner_next(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ids = dispatchable_task_ids(target)
+    if not ids:
+        print_json({"dispatchable": False, "task_id": None, "blocking_reasons": ["no ready task with worktree record"]})
+        return 1
+    task = load_task(target, ids[0])
+    print_json({"dispatchable": True, "task_id": task["id"], "goal_id": task["goal_id"], "branch": task["expected_branch"]})
+    return 0
+
+
+def cmd_runner_execute(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    ensure_control_dirs(target)
+    task = load_task(target, args.task_id)
+    if task.get("status") not in {"ready", "running"}:
+        raise ShikiError(f"task {args.task_id} is not ready for runner execution")
+    task["status"] = "running"
+    write_json(shiki_path(target, "tasks", f"{args.task_id}.json"), task)
+
+    process = subprocess.run(args.command, cwd=str(target), shell=True, text=True, capture_output=True, check=False)
+    record_id = next_control_id(target, "EXEC")
+    record_file = shiki_path(target, "runner", f"{record_id}.json")
+    record = {
+        "id": record_id,
+        "task_id": args.task_id,
+        "goal_id": task["goal_id"],
+        "command": args.command,
+        "returncode": process.returncode,
+        "stdout": process.stdout,
+        "stderr": process.stderr,
+        "created_at": utc_now(),
+    }
+    write_json(record_file, record)
+    ledger_id = append_ledger(
+        target,
+        goal_id=task["goal_id"],
+        task_id=args.task_id,
+        ledger_type="check",
+        summary=f"Runner command exited {process.returncode} for {args.task_id}",
+        evidence=[str(record_file.relative_to(target))],
+    )
+    task = load_task(target, args.task_id)
+    task.setdefault("ledger_evidence", []).append(ledger_id)
+    task["status"] = "ready" if process.returncode == 0 else "repair-needed"
+    write_json(shiki_path(target, "tasks", f"{args.task_id}.json"), task)
+    print_json({"task_id": args.task_id, "returncode": process.returncode, "runner_record": str(record_file), "ledger_id": ledger_id})
+    return process.returncode
+
+
+def cmd_smoke_live(args: argparse.Namespace) -> int:
+    target = target_path(args.target)
+    require_github_first_target(target)
+    require_tool("gh")
+    if args.dry_run and args.execute_github:
+        raise ShikiError("--dry-run and --execute-github cannot be used together")
+    repo = github_repo_from_origin(target)
+    if not repo:
+        raise ShikiError("could not infer GitHub repo from origin")
+    run(["gh", "auth", "status"], cwd=target)
+    run(["gh", "repo", "view", repo, "--json", "name"], cwd=target)
+
+    plan = read_json(Path(args.plan_file).expanduser().resolve())
+    require_grilled_plan(plan)
+    if args.dry_run:
+        smoke_id = next_control_id(target, "SMOKE")
+        smoke_file = shiki_path(target, "smoke", f"{smoke_id}.json")
+        payload = {
+            "id": smoke_id,
+            "repo": repo,
+            "dry_run": True,
+            "execute_github": False,
+            "plan_title": plan["title"],
+            "task_count": len(plan["tasks"]),
+            "created_at": utc_now(),
+        }
+        write_json(smoke_file, payload)
+        print_json({"smoke_id": smoke_id, "smoke_file": str(smoke_file), "dry_run": True, "task_count": len(plan["tasks"])})
+        return 0
+
+    result = orchestrate_plan(target, plan)
+    first_task = result["dispatchable_task_ids"][0] if result["dispatchable_task_ids"] else None
+    github_result: dict[str, Any] = {"executed": False}
+    if args.execute_github and first_task:
+        issue_result = create_github_issue_for_task(target, first_task)
+        if args.push_branch:
+            task = load_task(target, first_task)
+            run(["git", "checkout", "-B", task["expected_branch"]], cwd=target)
+            run(["git", "add", ".shiki"], cwd=target)
+            staged = run(["git", "diff", "--cached", "--quiet"], cwd=target, check=False)
+            if staged.returncode != 0:
+                run(["git", "commit", "-m", f"shiki: smoke evidence for {first_task}"], cwd=target)
+            run(["git", "push", "-u", "origin", task["expected_branch"]], cwd=target)
+        pr_result = create_github_pr_for_task(target, first_task, base=args.base)
+        github_result = {"executed": True, "task_id": first_task, "issue": issue_result, "pr": pr_result}
+
+    smoke_id = next_control_id(target, "SMOKE")
+    smoke_file = shiki_path(target, "smoke", f"{smoke_id}.json")
+    payload = {
+        "id": smoke_id,
+        "repo": repo,
+        "dry_run": args.dry_run,
+        "execute_github": args.execute_github,
+        "result": result,
+        "github": github_result,
+        "created_at": utc_now(),
+    }
+    write_json(smoke_file, payload)
+    output = {"smoke_id": smoke_id, "smoke_file": str(smoke_file), **result, "github": github_result}
+    print_json(output)
     return 0
 
 
@@ -1671,6 +1887,40 @@ def build_parser() -> argparse.ArgumentParser:
     run_command.add_argument("--target", default=".", help="Target repository path")
     run_command.add_argument("--plan", required=True, help="Plan id like P-0001 or path to a grilled plan JSON")
     run_command.set_defaults(func=cmd_run)
+
+    daemon = subcommands.add_parser("daemon", help="Run the Shiki background inbox processor")
+    daemon_subcommands = daemon.add_subparsers(dest="daemon_command", required=True)
+    daemon_enqueue = daemon_subcommands.add_parser("enqueue-plan", help="Queue a grilled plan for daemon processing")
+    daemon_enqueue.add_argument("--target", default=".", help="Target repository path")
+    daemon_enqueue.add_argument("--plan-file", required=True)
+    daemon_enqueue.set_defaults(func=cmd_daemon_enqueue_plan)
+    daemon_run = daemon_subcommands.add_parser("run", help="Process queued Shiki inbox items")
+    daemon_run.add_argument("--target", default=".", help="Target repository path")
+    daemon_run.add_argument("--once", action="store_true", help="Process at most one item and exit")
+    daemon_run.add_argument("--interval", type=float, default=5.0, help="Polling interval in seconds")
+    daemon_run.set_defaults(func=cmd_daemon_run)
+
+    runner = subcommands.add_parser("runner", help="Pick up and execute dispatchable Shiki tasks")
+    runner_subcommands = runner.add_subparsers(dest="runner_command", required=True)
+    runner_next = runner_subcommands.add_parser("next", help="Return the next dispatchable task")
+    runner_next.add_argument("--target", default=".", help="Target repository path")
+    runner_next.set_defaults(func=cmd_runner_next)
+    runner_execute = runner_subcommands.add_parser("execute", help="Execute a command for a ready task and record evidence")
+    runner_execute.add_argument("--target", default=".", help="Target repository path")
+    runner_execute.add_argument("--task-id", required=True)
+    runner_execute.add_argument("--command", required=True)
+    runner_execute.set_defaults(func=cmd_runner_execute)
+
+    smoke = subcommands.add_parser("smoke", help="Run live Shiki smoke checks against a GitHub-backed target")
+    smoke_subcommands = smoke.add_subparsers(dest="smoke_command", required=True)
+    smoke_live = smoke_subcommands.add_parser("live", help="Verify plan/run and optional GitHub issue/PR creation")
+    smoke_live.add_argument("--target", default=".", help="Target repository path")
+    smoke_live.add_argument("--plan-file", required=True)
+    smoke_live.add_argument("--dry-run", action="store_true", help="Run local plan orchestration without GitHub issue/PR creation")
+    smoke_live.add_argument("--execute-github", action="store_true", help="Also create GitHub issue and PR evidence")
+    smoke_live.add_argument("--push-branch", action="store_true", help="Create, commit, and push the smoke task branch before PR creation")
+    smoke_live.add_argument("--base", default="main")
+    smoke_live.set_defaults(func=cmd_smoke_live)
 
     goal = subcommands.add_parser("goal", help="Manage Shiki goals")
     goal_subcommands = goal.add_subparsers(dest="goal_command", required=True)

--- a/scripts/test_shiki_daemon_runner.sh
+++ b/scripts/test_shiki_daemon_runner.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/shiki-daemon-runner-test-$$"
+TARGET="$TMP_ROOT/target"
+FAKE_BIN="$TMP_ROOT/bin"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+json_get() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"
+}
+
+cd "$ROOT"
+
+python3 scripts/validate_shiki.py
+python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py
+python3 scripts/shiki.py --help | grep -E "daemon|runner|smoke" >/dev/null
+
+mkdir -p "$TARGET" "$FAKE_BIN"
+python3 scripts/shiki.py install-target "$TARGET" --local-only >/tmp/shiki-daemon-install.out
+
+cd "$TARGET"
+git init -b main >/tmp/shiki-daemon-git-init.out
+git remote add origin https://github.com/example/shiki-daemon-test.git
+
+cat >"$TMP_ROOT/plan.json" <<'JSON'
+{
+  "title": "Ship daemon smoke",
+  "outcome": "A background loop can convert a grilled plan into Shiki run state",
+  "completion_conditions": ["One task is dispatchable"],
+  "non_goals": ["Do not create real GitHub objects in this test"],
+  "risk_level": "low",
+  "required_skills": ["grill-with-docs", "tdd"],
+  "grill_with_docs": {
+    "status": "complete",
+    "source": "CONTEXT.md",
+    "decisions": ["Use one dispatchable task"]
+  },
+  "tasks": [
+    {
+      "title": "Write daemon marker",
+      "scope": "Create the smallest runner-visible task",
+      "acceptance_checks": ["Runner command records success"],
+      "locks": ["path:daemon-marker.txt"],
+      "required_skills": ["tdd"]
+    }
+  ]
+}
+JSON
+
+python3 "$ROOT/scripts/shiki.py" daemon enqueue-plan --target "$TARGET" --plan-file "$TMP_ROOT/plan.json" >/tmp/shiki-enqueue.json
+INBOX_FILE="$(json_get /tmp/shiki-enqueue.json inbox_file)"
+test -f "$INBOX_FILE"
+
+python3 "$ROOT/scripts/shiki.py" daemon run --target "$TARGET" --once >/tmp/shiki-daemon-run.json
+RUN_ID="$(json_get /tmp/shiki-daemon-run.json run_id)"
+test -f "$TARGET/.shiki/runs/$RUN_ID.json"
+test -z "$(find "$TARGET/.shiki/inbox" -maxdepth 1 -type f -name '*.json' -print -quit)"
+
+python3 "$ROOT/scripts/shiki.py" runner next --target "$TARGET" >/tmp/shiki-runner-next.json
+TASK_ID="$(json_get /tmp/shiki-runner-next.json task_id)"
+
+python3 "$ROOT/scripts/shiki.py" runner execute \
+  --target "$TARGET" \
+  --task-id "$TASK_ID" \
+  --command "printf runner-ok > daemon-marker.txt" \
+  >/tmp/shiki-runner-execute.json
+grep "runner-ok" "$TARGET/daemon-marker.txt" >/dev/null
+
+python3 "$ROOT/scripts/shiki.py" task status --target "$TARGET" "$TASK_ID" --status done >/tmp/shiki-daemon-task-done.json
+python3 "$ROOT/scripts/shiki.py" goal complete --target "$TARGET" "$(json_get /tmp/shiki-daemon-run.json goal_id)" >/tmp/shiki-daemon-goal-complete.json
+
+cat >"$FAKE_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >>"${SHIKI_FAKE_GH_LOG}"
+case "$1 $2" in
+  "auth status")
+    exit 0
+    ;;
+  "repo view")
+    echo '{"name":"shiki-daemon-test"}'
+    exit 0
+    ;;
+  "issue create")
+    echo "https://github.com/example/shiki-daemon-test/issues/88"
+    exit 0
+    ;;
+  "pr create")
+    echo "https://github.com/example/shiki-daemon-test/pull/99"
+    exit 0
+    ;;
+esac
+echo "fake gh unsupported: $*" >&2
+exit 1
+SH
+chmod +x "$FAKE_BIN/gh"
+export PATH="$FAKE_BIN:$PATH"
+export SHIKI_FAKE_GH_LOG="$TMP_ROOT/gh.log"
+
+cat >"$TMP_ROOT/smoke-plan.json" <<'JSON'
+{
+  "title": "Ship live smoke",
+  "outcome": "A live smoke can create GitHub evidence for a fresh task",
+  "completion_conditions": ["One smoke task is dispatchable"],
+  "non_goals": ["Do not depend on previous daemon locks"],
+  "risk_level": "low",
+  "required_skills": ["grill-with-docs", "tdd"],
+  "grill_with_docs": {
+    "status": "complete",
+    "source": "CONTEXT.md",
+    "decisions": ["Use a separate smoke lock"]
+  },
+  "tasks": [
+    {
+      "title": "Write smoke marker",
+      "scope": "Create the smallest GitHub-visible smoke task",
+      "acceptance_checks": ["GitHub issue and PR evidence is recorded"],
+      "locks": ["path:smoke-marker.txt"],
+      "required_skills": ["tdd"]
+    }
+  ]
+}
+JSON
+
+python3 "$ROOT/scripts/shiki.py" smoke live \
+  --target "$TARGET" \
+  --plan-file "$TMP_ROOT/smoke-plan.json" \
+  --dry-run \
+  >/tmp/shiki-smoke-dry-run.json
+grep "auth status" "$SHIKI_FAKE_GH_LOG" >/dev/null
+
+python3 "$ROOT/scripts/shiki.py" smoke live \
+  --target "$TARGET" \
+  --plan-file "$TMP_ROOT/smoke-plan.json" \
+  --execute-github \
+  >/tmp/shiki-smoke-execute.json
+grep "issue create" "$SHIKI_FAKE_GH_LOG" >/dev/null
+grep "pr create" "$SHIKI_FAKE_GH_LOG" >/dev/null
+
+test -f "$ROOT/.github/workflows/shiki-orchestrator.yml"
+grep "workflow_dispatch" "$ROOT/.github/workflows/shiki-orchestrator.yml" >/dev/null
+grep "issue_comment" "$ROOT/.github/workflows/shiki-orchestrator.yml" >/dev/null
+
+python3 "$TARGET/scripts/validate_shiki.py"
+
+echo "shiki daemon runner tests passed"

--- a/scripts/validate_shiki.py
+++ b/scripts/validate_shiki.py
@@ -18,6 +18,9 @@ GOAL_ID = re.compile(r"^G-[0-9]{4,}$")
 LEDGER_ID = re.compile(r"^L-[0-9]{4,}$")
 PLAN_ID = re.compile(r"^P-[0-9]{4,}$")
 RUN_ID = re.compile(r"^RUN-[0-9]{4,}$")
+INBOX_ID = re.compile(r"^INBOX-[0-9]{4,}$")
+EXEC_ID = re.compile(r"^EXEC-[0-9]{4,}$")
+SMOKE_ID = re.compile(r"^SMOKE-[0-9]{4,}$")
 
 TASK_REQUIRED = {
     "id",
@@ -48,6 +51,8 @@ RUN_REQUIRED = {
     "worktrees",
     "created_at",
 }
+RUNNER_REQUIRED = {"id", "task_id", "goal_id", "command", "returncode", "stdout", "stderr", "created_at"}
+SMOKE_REQUIRED = {"id", "repo", "dry_run", "execute_github", "created_at"}
 
 RUNTIMES = {
     "codex",
@@ -313,6 +318,40 @@ def validate_run(path: Path, data: dict[str, Any], known_tasks: set[str]) -> Non
     require_list(path, data, "worktrees")
 
 
+def validate_runner_record(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
+    require_keys(path, data, RUNNER_REQUIRED)
+    exec_id = require_string(path, data, "id")
+    if not EXEC_ID.match(exec_id):
+        raise ValidationError(f"{path}: id must match EXEC-0001 style")
+    task_id = require_string(path, data, "task_id")
+    if not TASK_ID.match(task_id):
+        raise ValidationError(f"{path}: task_id must match T-0001 style")
+    if known_tasks and task_id not in known_tasks:
+        raise ValidationError(f"{path}: task_id {task_id} has no matching task file")
+    goal_id = require_string(path, data, "goal_id")
+    if not GOAL_ID.match(goal_id):
+        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_string(path, data, "command")
+    if not isinstance(data.get("returncode"), int):
+        raise ValidationError(f"{path}: returncode must be an integer")
+    require_string(path, data, "stdout", non_empty=False)
+    require_string(path, data, "stderr", non_empty=False)
+    require_string(path, data, "created_at")
+
+
+def validate_smoke(path: Path, data: dict[str, Any]) -> None:
+    require_keys(path, data, SMOKE_REQUIRED)
+    smoke_id = require_string(path, data, "id")
+    if not SMOKE_ID.match(smoke_id):
+        raise ValidationError(f"{path}: id must match SMOKE-0001 style")
+    require_string(path, data, "repo")
+    if not isinstance(data.get("dry_run"), bool):
+        raise ValidationError(f"{path}: dry_run must be a boolean")
+    if not isinstance(data.get("execute_github"), bool):
+        raise ValidationError(f"{path}: execute_github must be a boolean")
+    require_string(path, data, "created_at")
+
+
 def json_files(directory: Path) -> list[Path]:
     if not directory.exists():
         return []
@@ -373,6 +412,18 @@ def main() -> int:
             if not isinstance(data, dict):
                 raise ValidationError(f"{run_path}: run must be a JSON object")
             validate_run(run_path, data, known_tasks)
+
+        for runner_path in json_files(SHIKI / "runner"):
+            data = load_json(runner_path)
+            if not isinstance(data, dict):
+                raise ValidationError(f"{runner_path}: runner record must be a JSON object")
+            validate_runner_record(runner_path, data, known_tasks)
+
+        for smoke_path in json_files(SHIKI / "smoke"):
+            data = load_json(smoke_path)
+            if not isinstance(data, dict):
+                raise ValidationError(f"{smoke_path}: smoke record must be a JSON object")
+            validate_smoke(smoke_path, data)
 
     except ValidationError as error:
         errors.append(str(error))


### PR DESCRIPTION
## Shiki
Goal: G-0001
Task: T-0009
CCA checklist profile: PR, TDD, V, CCA

## Scope
Implement the remaining automation layer so users can queue grill-with-docs plans for background processing, run headless task commands with ledger evidence, smoke-test a real GitHub-backed target, and trigger Shiki orchestration from GitHub Actions.

## Non-goals
- Do not bypass branch protection.
- Do not create real GitHub issues or PRs in local tests.
- Do not require non-standard Python dependencies.
- Do not hard-code Codex or Hermes as the only runner runtime.

## Acceptance
- shiki daemon enqueue-plan queues a completed grill-with-docs plan in .shiki/inbox.
- shiki daemon run processes queued plans into Goal, Task DAG, locks, worktree, run, and ledger evidence.
- shiki runner next returns the next dispatchable task.
- shiki runner execute runs a supplied headless runtime command and records stdout, stderr, return code, and ledger evidence.
- shiki smoke live --dry-run validates GitHub auth/repo and plan shape without creating GitHub objects.
- shiki smoke live --execute-github creates GitHub Issue/PR evidence through the Shiki task state.
- shiki smoke live --execute-github --push-branch can create, commit, and push the smoke branch before PR creation.
- .github/workflows/shiki-orchestrator.yml supports workflow_dispatch and /shiki issue comments.
- scripts/validate_shiki.py validates runner and smoke records.
- CI runs scripts/test_shiki_daemon_runner.sh.

## Evidence
- python3 scripts/validate_shiki.py
- python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py
- bash scripts/test_shiki_init.sh
- bash scripts/test_shiki_control_plane.sh
- bash scripts/test_shiki_run_orchestrator.sh
- bash scripts/test_shiki_daemon_runner.sh
- ruby YAML load for .github/workflows/*.yml

## Ledger evidence
- L-0011: task registration evidence for T-0009.
- L-0012: T-0008 dependency completion evidence from PR #15.

## MergeGate
- Locks: path:scripts/shiki.py, path:scripts/validate_shiki.py, path:scripts/test_shiki_daemon_runner.sh, path:.github/workflows/shiki-validate.yml, path:.github/workflows/shiki-orchestrator.yml, path:.claude/commands/shiki.md, path:.codex/skills/shiki/SKILL.md, path:docs/agents/bootstrap-command.md, path:docs/agents/control-commands.md, path:.shiki/schemas/inbox.schema.json, path:.shiki/schemas/runner-record.schema.json, path:.shiki/schemas/smoke.schema.json, path:.shiki/tasks/T-0008.json, path:.shiki/tasks/T-0009.json, path:.shiki/ledger/L-0011.json, path:.shiki/ledger/L-0012.json
- Risk: medium
- CCA required: yes
- Merge only after required checks pass.