### PR TITLE
feat: add one-command Shiki start flow

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -18,17 +18,43 @@ Run:
 shiki status
 ```
 
-If the current repository does not have Shiki installed and the user asked to
-set up the repository, do not run a local-only install. Ask for the GitHub repo
-slug if it is not provided, then run:
+If the current repository does not have Shiki installed, do not hand the user a
+manual checklist. Ask only for the missing values, one question at a time, then
+run `shiki start`.
+
+Required start questions:
+
+1. GitHub repo slug: `OWNER/REPO`
+2. Project name
+3. Goal title
+4. Outcome / completion result
+5. Completion conditions
+6. Non-goals
+7. First vertical-slice task and acceptance checks
+
+Ask these in the `grill-with-docs` style: one question at a time, with a
+recommended answer when enough context exists. Explore the repository instead
+of asking when the answer is discoverable locally.
+
+Once enough answers are known, create a temporary answers JSON and run one
+command:
 
 ```bash
-shiki init . --repo OWNER/NAME
+shiki start . --answers-file ANSWERS.json
 ```
+
+Use `shiki init`, `shiki plan ingest`, or `shiki run` directly only for repair,
+debugging, or explicit advanced control. The normal user-facing entrypoint is
+`shiki start`.
+
+The default engineering Skill Gate directory is
+`/Users/kio.mizutani/Documents/lead-os/skills/engineering` when present. Preserve
+the selected skills directory in the start record, plan, and handoff evidence.
 
 ## Operating Rules
 
 - Treat Codex as implementer, CCA as completion judge, and MergeGate as merge authorization.
+- Treat `/shiki` as a guided one-command entrypoint. Do not ask the user to run multiple setup commands.
 - For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.
 - After `grill-with-docs` is settled, prefer `shiki plan ingest` and `shiki run` over manually calling each lower-level command.
 - For unattended execution, queue settled plans with `shiki daemon enqueue-plan` and process them with `shiki daemon run`.

--- a/.codex/skills/shiki/SKILL.md
+++ b/.codex/skills/shiki/SKILL.md
@@ -19,13 +19,17 @@ shiki status
 Then inspect the target repository's `AGENTS.md`, `CLAUDE.md`, `CONTEXT.md`,
 `.shiki/`, `docs/agents/`, and open PR/issue state before changing files.
 
-If Shiki is not installed in the target repository, do not use a local-only
-template install by default. Ask for the GitHub repository slug if it is
-missing, then run:
+If Shiki is not installed in the target repository, do not give the user a
+manual sequence. Ask for the missing repo and Goal values one question at a
+time, then run the one-command entrypoint:
 
 ```bash
-shiki init . --repo OWNER/NAME
+shiki start . --repo OWNER/NAME --goal "..." --outcome "..."
 ```
+
+The default engineering Skill Gate directory is
+`/Users/kio.mizutani/Documents/lead-os/skills/engineering` when present. The
+start record, plan, and handoff must preserve the selected skills directory.
 
 ## Responsibilities
 
@@ -38,6 +42,7 @@ shiki init . --repo OWNER/NAME
 ## Rules
 
 - For non-trivial goals, enter through `grill-with-docs`.
+- `/shiki` should guide the user through missing repo/Goal answers one question at a time and then run `shiki start`; direct `init`, `plan`, and `run` calls are lower-level fallback commands.
 - Convert the settled `grill-with-docs` result into a machine-readable plan and run it with `shiki plan ingest` followed by `shiki run`.
 - For unattended execution, queue the plan with `shiki daemon enqueue-plan` and process it with `shiki daemon run`.
 - For headless runtime integration, use `shiki runner next` and `shiki runner execute` to pick up ready tasks and record execution evidence.
@@ -52,6 +57,7 @@ shiki init . --repo OWNER/NAME
 ## Commands
 
 - `shiki install-global`
+- `shiki start /path/to/repo --repo OWNER/REPO --goal "..." --outcome "..."`
 - `shiki init /path/to/repo --repo OWNER/REPO`
 - `shiki preflight --require-github`
 - `shiki plan guide --prompt "..."`

--- a/.github/workflows/shiki-validate.yml
+++ b/.github/workflows/shiki-validate.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run Shiki daemon and runner contract test
         run: bash scripts/test_shiki_daemon_runner.sh
+
+      - name: Run Shiki one-command start contract test
+        run: bash scripts/test_shiki_start.sh

--- a/.shiki/ledger/L-0014.json
+++ b/.shiki/ledger/L-0014.json
@@ -1,0 +1,16 @@
+{
+  "id": "L-0014",
+  "timestamp": "2026-05-29T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0010",
+  "type": "task-registered",
+  "actor": "codex-front",
+  "summary": "Registered one-command guided /shiki start implementation with TDD evidence requirements.",
+  "evidence": [
+    ".shiki/tasks/T-0010.json",
+    "scripts/test_shiki_start.sh",
+    "scripts/shiki.py",
+    ".claude/commands/shiki.md"
+  ],
+  "links": []
+}

--- a/.shiki/ledger/L-0015.json
+++ b/.shiki/ledger/L-0015.json
@@ -1,0 +1,19 @@
+{
+  "id": "L-0015",
+  "timestamp": "2026-05-29T00:00:00+00:00",
+  "goal_id": "G-0001",
+  "task_id": "T-0009",
+  "type": "completion",
+  "actor": "codex-front",
+  "summary": "Marked T-0009 complete after PR #16 merged with Validate, CCA, and MergeGate checks passing.",
+  "evidence": [
+    "PR #16 merged: https://github.com/mizutani-140/shiki/pull/16",
+    "Merge commit: afdd24f98a4cc5dddbaf999024fb3acd479734e3",
+    "CCA verdict: success",
+    "MergeGate policy check: success",
+    "Validate Shiki mirror: success"
+  ],
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/16"
+  ]
+}

--- a/.shiki/ledger/L-0016.json
+++ b/.shiki/ledger/L-0016.json
@@ -1,0 +1,16 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    ".shiki/tasks/T-0010.json",
+    "https://github.com/mizutani-140/shiki/pull/17"
+  ],
+  "goal_id": "G-0001",
+  "id": "L-0016",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/17"
+  ],
+  "summary": "Opened PR #17 for the one-command guided Shiki start flow.",
+  "task_id": "T-0010",
+  "timestamp": "2026-05-29T07:26:16+00:00",
+  "type": "handoff"
+}

--- a/.shiki/ledger/L-0017.json
+++ b/.shiki/ledger/L-0017.json
@@ -1,0 +1,19 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    ".shiki/tasks/T-0010.json",
+    ".claude/commands/shiki.md",
+    ".codex/skills/shiki/SKILL.md",
+    "docs/agents/bootstrap-command.md",
+    "docs/agents/control-commands.md"
+  ],
+  "goal_id": "G-0001",
+  "id": "L-0017",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/17"
+  ],
+  "summary": "Skill Gate evidence: grill-with-docs was used for T-0010 to resolve that /shiki must ask missing repository and Goal values one question at a time, then run shiki start as the single command. Decisions: use GitHub-first start by default, persist the selected engineering skills directory, keep init/plan/run as lower-level fallback commands, and make the first generated task a vertical slice with acceptance checks.",
+  "task_id": "T-0010",
+  "timestamp": "2026-05-29T07:32:31+00:00",
+  "type": "context-impact"
+}

--- a/.shiki/schemas/start.schema.json
+++ b/.shiki/schemas/start.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://shiki.local/schemas/start.schema.json",
+  "title": "Shiki Start Record",
+  "type": "object",
+  "required": [
+    "id",
+    "repo",
+    "project_name",
+    "skills_dir",
+    "questions",
+    "plan_id",
+    "goal_id",
+    "run_id",
+    "dispatchable_task_ids",
+    "issues",
+    "handoffs",
+    "created_at"
+  ],
+  "properties": {
+    "id": { "type": "string", "pattern": "^START-[0-9]{4,}$" },
+    "repo": { "type": "string", "minLength": 1 },
+    "project_name": { "type": "string", "minLength": 1 },
+    "skills_dir": { "type": "string", "minLength": 1 },
+    "questions": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1
+    },
+    "plan_id": { "type": "string", "pattern": "^P-[0-9]{4,}$" },
+    "goal_id": { "type": "string", "pattern": "^G-[0-9]{4,}$" },
+    "run_id": { "type": "string", "pattern": "^RUN-[0-9]{4,}$" },
+    "dispatchable_task_ids": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^T-[0-9]{4,}$" }
+    },
+    "issues": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "handoffs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "created_at": { "type": "string", "minLength": 1 }
+  },
+  "additionalProperties": true
+}

--- a/.shiki/tasks/T-0009.json
+++ b/.shiki/tasks/T-0009.json
@@ -30,7 +30,8 @@
     "path:.shiki/tasks/T-0009.json",
     "path:.shiki/ledger/L-0011.json",
     "path:.shiki/ledger/L-0012.json",
-    "path:.shiki/ledger/L-0013.json"
+    "path:.shiki/ledger/L-0013.json",
+    "path:.shiki/ledger/L-0015.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -52,7 +53,8 @@
   "expected_pr": 16,
   "ledger_evidence": [
     "L-0011",
-    "L-0013"
+    "L-0013",
+    "L-0015"
   ],
-  "status": "review"
+  "status": "done"
 }

--- a/.shiki/tasks/T-0010.json
+++ b/.shiki/tasks/T-0010.json
@@ -1,0 +1,55 @@
+{
+  "id": "T-0010",
+  "goal_id": "G-0001",
+  "github_issue": null,
+  "title": "Make /shiki a one-command guided start flow",
+  "scope": "Replace the multi-command user setup path with a guided one-command start flow that asks for missing repository and Goal settings, initializes the GitHub-first repository, persists a grilled plan, runs Shiki orchestration, creates the first GitHub issue, and writes handoff evidence.",
+  "non_goals": [
+    "Do not remove lower-level init, plan, run, daemon, runner, or smoke commands.",
+    "Do not bypass branch protection.",
+    "Do not create real GitHub repositories in local tests.",
+    "Do not skip grill-with-docs as the conceptual planning gate."
+  ],
+  "dependencies": [
+    "T-0009"
+  ],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/validate_shiki.py",
+    "path:scripts/test_shiki_start.sh",
+    "path:.github/workflows/shiki-validate.yml",
+    "path:.claude/commands/shiki.md",
+    "path:.codex/skills/shiki/SKILL.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:docs/agents/control-commands.md",
+    "path:.shiki/schemas/start.schema.json",
+    "path:.shiki/tasks/T-0009.json",
+    "path:.shiki/tasks/T-0010.json",
+    "path:.shiki/ledger/L-0014.json",
+    "path:.shiki/ledger/L-0015.json"
+  ],
+  "assigned_runtime": "codex-front",
+  "risk_level": "medium",
+  "required_skills": [
+    "shiki",
+    "grill-with-docs",
+    "tdd"
+  ],
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py",
+    "python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py",
+    "bash scripts/test_shiki_init.sh",
+    "bash scripts/test_shiki_control_plane.sh",
+    "bash scripts/test_shiki_run_orchestrator.sh",
+    "bash scripts/test_shiki_daemon_runner.sh",
+    "bash scripts/test_shiki_start.sh",
+    "Validate Shiki mirror runs the one-command start contract test in CI.",
+    "PR evidence includes CCA and MergeGate success."
+  ],
+  "expected_branch": "shiki-one-command-start",
+  "expected_pr": null,
+  "ledger_evidence": [
+    "L-0014"
+  ],
+  "status": "review"
+}

--- a/.shiki/tasks/T-0010.json
+++ b/.shiki/tasks/T-0010.json
@@ -26,7 +26,8 @@
     "path:.shiki/tasks/T-0009.json",
     "path:.shiki/tasks/T-0010.json",
     "path:.shiki/ledger/L-0014.json",
-    "path:.shiki/ledger/L-0015.json"
+    "path:.shiki/ledger/L-0015.json",
+    "path:.shiki/ledger/L-0016.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -47,9 +48,10 @@
     "PR evidence includes CCA and MergeGate success."
   ],
   "expected_branch": "shiki-one-command-start",
-  "expected_pr": null,
+  "expected_pr": 17,
   "ledger_evidence": [
-    "L-0014"
+    "L-0014",
+    "L-0016"
   ],
   "status": "review"
 }

--- a/.shiki/tasks/T-0010.json
+++ b/.shiki/tasks/T-0010.json
@@ -27,7 +27,8 @@
     "path:.shiki/tasks/T-0010.json",
     "path:.shiki/ledger/L-0014.json",
     "path:.shiki/ledger/L-0015.json",
-    "path:.shiki/ledger/L-0016.json"
+    "path:.shiki/ledger/L-0016.json",
+    "path:.shiki/ledger/L-0017.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -51,7 +52,8 @@
   "expected_pr": 17,
   "ledger_evidence": [
     "L-0014",
-    "L-0016"
+    "L-0016",
+    "L-0017"
   ],
   "status": "review"
 }

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -17,13 +17,13 @@ This creates or updates:
 Ensure `~/.local/bin` is on `PATH`. Restart Codex or Claude Code if the
 running client does not reload commands dynamically.
 
-## Initialize A Target Repository
+## Start A Target Repository
 
 ```bash
-shiki init /path/to/target-repo --repo OWNER/REPO --private
+shiki start /path/to/target-repo --repo OWNER/REPO --private
 ```
 
-This is the standard Shiki entrypoint. It will:
+This is the standard user-facing Shiki entrypoint. It will:
 
 - install Shiki template files;
 - initialize Git if needed;
@@ -32,7 +32,21 @@ This is the standard Shiki entrypoint. It will:
 - write `.shiki/repo.json`;
 - commit and push the initial Shiki state;
 - set `CLAUDE_CODE_OAUTH_TOKEN` from the environment when present;
-- configure branch protection with Shiki required checks when GitHub permissions allow it.
+- configure branch protection with Shiki required checks when GitHub permissions allow it;
+- collect or consume Goal answers;
+- write a machine-readable plan;
+- run Shiki orchestration;
+- create the first task issue and handoff evidence.
+
+`shiki init` is still available as a lower-level command, but `/shiki` should
+prefer `shiki start` unless the user explicitly asks for advanced control.
+
+`shiki start` may run interactively. When values are missing, it asks one
+question at a time for the GitHub repo slug, project name, Goal, outcome,
+completion conditions, non-goals, and first vertical slice. The selected
+engineering Skill Gate directory is recorded in `.shiki/starts/`, the plan, and
+handoff evidence. By default, Shiki uses
+`/Users/kio.mizutani/Documents/lead-os/skills/engineering` when present.
 
 Do not use `install-target` for normal setup. Shiki is GitHub-first.
 

--- a/docs/agents/control-commands.md
+++ b/docs/agents/control-commands.md
@@ -5,6 +5,36 @@ with `shiki init TARGET --repo OWNER/REPO`. Control commands refuse to run when
 the target does not have a `.shiki` mirror, a git repository, and a GitHub
 `origin`.
 
+## One Command Start
+
+For normal use, `/shiki` should ask the missing questions and then run:
+
+```bash
+shiki start /path/to/repo --repo OWNER/REPO --goal "Goal title" --outcome "Observable outcome"
+```
+
+`shiki start` is the single command that performs GitHub-first setup, persists a
+settled `grill-with-docs` plan, runs the Shiki orchestrator, creates the first
+GitHub task issue, writes handoff evidence, commits the resulting state, and
+pushes it unless disabled with `--no-push`.
+
+The default engineering Skill Gate directory is
+`/Users/kio.mizutani/Documents/lead-os/skills/engineering` when it exists, or
+`~/skills/skills/engineering` otherwise. Override it with `--skills-dir` when a
+target repository uses a different skills checkout.
+
+When Claude Code invokes `/shiki`, it should ask for these values one at a time
+instead of asking the user to manually chain setup commands:
+
+- GitHub repo slug
+- Project name
+- Goal title
+- Observable outcome
+- Completion conditions
+- Non-goals
+- First vertical-slice task
+- Acceptance checks
+
 ## Standard Flow
 
 For non-trivial work, do not start by manually creating each task. First run

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -51,6 +51,7 @@ TEMPLATE_PATHS = [
     "scripts/test_shiki_control_plane.sh",
     "scripts/test_shiki_run_orchestrator.sh",
     "scripts/test_shiki_daemon_runner.sh",
+    "scripts/test_shiki_start.sh",
 ]
 
 DEFAULT_REQUIRED_CHECKS = [
@@ -62,6 +63,22 @@ DEFAULT_REQUIRED_CHECKS = [
 DEFAULT_GLOBAL_COMMAND_PATH = "~/.local/bin/shiki"
 DEFAULT_CLAUDE_COMMAND_PATH = "~/.claude/commands/shiki.md"
 DEFAULT_CODEX_SKILL_PATH = "~/.codex/skills/shiki/SKILL.md"
+DEFAULT_ENGINEERING_SKILLS_DIRS = [
+    "~/Documents/lead-os/skills/engineering",
+    "~/skills/skills/engineering",
+]
+START_QUESTIONS = [
+    "GitHub repo slug (OWNER/REPO)",
+    "Project name",
+    "Goal title",
+    "Outcome / success result",
+    "Completion conditions",
+    "Non-goals",
+    "First vertical-slice task title",
+    "First task scope",
+    "First task acceptance checks",
+    "First task locks",
+]
 TARGET_STATE_DIRECTORIES = [
     ".shiki/goals",
     ".shiki/plans",
@@ -77,6 +94,7 @@ TARGET_STATE_DIRECTORIES = [
     ".shiki/handoffs",
     ".shiki/runner",
     ".shiki/smoke",
+    ".shiki/starts",
 ]
 GITHUB_REPO = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -325,6 +343,67 @@ def print_json(data: dict[str, Any]) -> None:
 def slugify(value: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9]+", "-", value.lower()).strip("-")
     return slug[:48] or "task"
+
+
+def prompt_value(label: str, current: str | None = None, *, required: bool = True) -> str:
+    if current:
+        return current
+    if not sys.stdin.isatty():
+        if required:
+            raise ShikiError(f"missing {label}; pass it as an option or use --answers-file")
+        return ""
+    while True:
+        value = input(f"{label}: ").strip()
+        if value or not required:
+            return value
+
+
+def prompt_default(label: str, default: str) -> str:
+    if not sys.stdin.isatty():
+        return default
+    value = input(f"{label} [{default}]: ").strip()
+    return value or default
+
+
+def prompt_list(label: str, current: list[str] | None = None) -> list[str]:
+    if current:
+        return current
+    if not sys.stdin.isatty():
+        return []
+    print(f"{label}: enter one item per line, then an empty line.")
+    values: list[str] = []
+    while True:
+        value = input("> ").strip()
+        if not value:
+            break
+        values.append(value)
+    return values
+
+
+def default_engineering_skills_dir() -> str:
+    configured = os.environ.get("SHIKI_ENGINEERING_SKILLS_DIR")
+    if configured:
+        return configured
+    for candidate in DEFAULT_ENGINEERING_SKILLS_DIRS:
+        path = Path(candidate).expanduser()
+        if path.exists():
+            return str(path)
+    return DEFAULT_ENGINEERING_SKILLS_DIRS[0]
+
+
+def resolve_engineering_skills_dir(value: str | None) -> str:
+    skills_dir = value or default_engineering_skills_dir()
+    if value and not Path(value).expanduser().exists():
+        raise ShikiError(f"engineering skills directory does not exist: {value}")
+    return skills_dir
+
+
+def start_target_value(args: argparse.Namespace) -> str:
+    positional = getattr(args, "target_positional", None)
+    option = getattr(args, "target", ".")
+    if positional and option != "." and Path(positional).expanduser().resolve() != Path(option).expanduser().resolve():
+        raise ShikiError("pass the target repository either positionally or with --target, not both")
+    return positional or option
 
 
 def scan_ids(target: Path, prefix: str) -> list[int]:
@@ -828,6 +907,238 @@ def cmd_run(args: argparse.Namespace) -> int:
         plan = load_plan(target, args.plan)
 
     print_json(orchestrate_plan(target, plan))
+    return 0
+
+
+def load_start_answers(args: argparse.Namespace) -> dict[str, Any]:
+    answers: dict[str, Any] = {}
+    if args.answers_file:
+        answers = read_json(Path(args.answers_file).expanduser().resolve())
+
+    repo = args.repo or answers.get("repo")
+    goal = args.goal or answers.get("goal") or answers.get("title")
+    outcome = args.outcome or answers.get("outcome")
+    project_name = args.project_name or answers.get("project_name") or goal
+    skills_dir = resolve_engineering_skills_dir(args.skills_dir or answers.get("skills_dir"))
+
+    repo = prompt_value("GitHub repo slug (OWNER/REPO)", repo)
+    require_github_repo_slug(repo)
+    goal = prompt_value("Goal title", goal)
+    outcome = prompt_value("Outcome / success result", outcome)
+    project_name = prompt_default("Project name", project_name) if project_name else prompt_value("Project name", project_name)
+
+    completion_conditions = args.completion_condition or answers.get("completion_conditions") or []
+    if not completion_conditions:
+        completion_conditions = prompt_list("Completion conditions")
+    if not completion_conditions:
+        completion_conditions = [outcome]
+
+    non_goals = args.non_goal or answers.get("non_goals") or []
+    if not non_goals:
+        non_goals = prompt_list("Non-goals")
+
+    required_skills = args.required_skill or answers.get("required_skills") or [
+        "grill-with-docs",
+        "to-prd",
+        "to-issues",
+        "tdd",
+    ]
+    tasks = answers.get("tasks")
+    if not tasks:
+        if sys.stdin.isatty():
+            task_title = prompt_default("First vertical-slice task title", args.task_title or f"Implement first vertical slice for {goal}")
+            task_scope = prompt_default("First task scope", args.task_scope or f"Create the smallest end-to-end implementation path for {outcome}")
+            acceptance_checks = prompt_list("First task acceptance checks", args.acceptance_check) or [f"User can verify: {outcome}"]
+            locks = prompt_list("First task locks", args.lock) or ["path:**/*"]
+        else:
+            task_title = args.task_title or f"Implement first vertical slice for {goal}"
+            task_scope = args.task_scope or f"Create the smallest end-to-end implementation path for {outcome}"
+            acceptance_checks = args.acceptance_check or [f"User can verify: {outcome}"]
+            locks = args.lock or ["path:**/*"]
+        tasks = [
+            {
+                "title": task_title,
+                "scope": task_scope,
+                "acceptance_checks": acceptance_checks,
+                "locks": locks,
+                "required_skills": ["tdd"],
+            }
+        ]
+
+    return {
+        "repo": repo,
+        "project_name": project_name,
+        "goal": goal,
+        "outcome": outcome,
+        "completion_conditions": completion_conditions,
+        "non_goals": non_goals,
+        "risk_level": args.risk_level or answers.get("risk_level", "medium"),
+        "required_skills": required_skills,
+        "skills_dir": skills_dir,
+        "tasks": tasks,
+    }
+
+
+def plan_from_start_answers(answers: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "title": answers["goal"],
+        "outcome": answers["outcome"],
+        "completion_conditions": answers["completion_conditions"],
+        "non_goals": answers["non_goals"],
+        "risk_level": answers["risk_level"],
+        "required_skills": answers["required_skills"],
+        "grill_with_docs": {
+            "status": "complete",
+            "source": "shiki start interactive questions",
+            "decisions": [
+                f"Project name: {answers['project_name']}",
+                f"GitHub repository: {answers['repo']}",
+                f"Engineering skills directory: {answers['skills_dir']}",
+                "Use GitHub-first Shiki setup.",
+                "Use engineering skills as mandatory planning and implementation gates.",
+                "Use a guided one-question-at-a-time start flow before creating the Task DAG.",
+            ],
+        },
+        "skill_gate": {
+            "skills_dir": answers["skills_dir"],
+            "required_skills": answers["required_skills"],
+            "entry_policy": "Ask missing Goal and repository values one at a time, then run shiki start as the single command.",
+        },
+        "tasks": answers["tasks"],
+    }
+
+
+def initialize_target_from_start(args: argparse.Namespace, target: Path, repo: str) -> None:
+    init_args = argparse.Namespace(
+        target=str(target),
+        repo=repo,
+        branch=args.branch,
+        private=args.private,
+        public=not args.private,
+        force=args.force,
+        validate=args.validate,
+        commit=args.commit,
+        commit_message=args.commit_message,
+        push=args.push,
+        set_secret=args.set_secret,
+        secret_env=args.secret_env,
+        protect=args.protect,
+        required_check=args.required_check,
+    )
+    cmd_init(init_args)
+
+
+def create_issues_for_dispatchable_tasks(target: Path, task_ids: list[str]) -> list[dict[str, Any]]:
+    issues: list[dict[str, Any]] = []
+    for task_id in task_ids:
+        issues.append(create_github_issue_for_task(target, task_id))
+    return issues
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    target = target_path(start_target_value(args))
+    target.mkdir(parents=True, exist_ok=True)
+    answers = load_start_answers(args)
+
+    already_initialized = (target / ".shiki" / "repo.json").exists() and is_git_repo(target) and github_origin(target)
+    if not already_initialized:
+        initialize_target_from_start(args, target, answers["repo"])
+    else:
+        require_github_first_target(target)
+        ensure_control_dirs(target)
+
+    plan = plan_from_start_answers(answers)
+    plan_id = next_control_id(target, "P")
+    plan["id"] = plan_id
+    plan["status"] = "ingested"
+    plan["source_file"] = "shiki start"
+    plan["ingested_at"] = utc_now()
+    plan_file = shiki_path(target, "plans", f"{plan_id}.json")
+    write_json(plan_file, plan)
+
+    result = orchestrate_plan(target, plan)
+    issues: list[dict[str, Any]] = []
+    if args.create_issues and result["dispatchable_task_ids"]:
+        issues = create_issues_for_dispatchable_tasks(target, result["dispatchable_task_ids"])
+
+    handoffs: list[str] = []
+    if args.create_handoffs:
+        for task_id in result["dispatchable_task_ids"]:
+            task = load_task(target, task_id)
+            handoff_file = write_handoff(
+                target,
+                f"{task_id}-task.md",
+                "\n".join(
+                    [
+                        f"# Codex Task Handoff: {task_id}",
+                        "",
+                        f"Goal: {task['goal_id']}",
+                        f"Task: {task_id}",
+                        f"Branch: {task['expected_branch']}",
+                        "",
+                        "## Scope",
+                        task["scope"],
+                        "",
+                        "## Required Skills",
+                        *[f"- {skill}" for skill in task.get("required_skills", [])],
+                        "",
+                        "## Engineering Skills Directory",
+                        answers["skills_dir"],
+                        "",
+                        "## Acceptance Checks",
+                        *[f"- {check}" for check in task.get("acceptance_checks", [])],
+                        "",
+                    ]
+                ),
+            )
+            handoffs.append(str(handoff_file.relative_to(target)))
+
+    start_id = next_control_id(target, "START")
+    start_file = shiki_path(target, "starts", f"{start_id}.json")
+    start_record = {
+        "id": start_id,
+        "repo": answers["repo"],
+        "project_name": answers["project_name"],
+        "skills_dir": answers["skills_dir"],
+        "questions": START_QUESTIONS,
+        "plan_id": plan_id,
+        "goal_id": result["goal_id"],
+        "run_id": result["run_id"],
+        "dispatchable_task_ids": result["dispatchable_task_ids"],
+        "issues": issues,
+        "handoffs": handoffs,
+        "created_at": utc_now(),
+    }
+    write_json(start_file, start_record)
+    ledger_id = append_ledger(
+        target,
+        goal_id=result["goal_id"],
+        ledger_type="handoff",
+        summary=f"Shiki start {start_id} initialized {answers['repo']}",
+        evidence=[str(start_file.relative_to(target)), str(plan_file.relative_to(target))],
+        links=[issue["url"] for issue in issues],
+    )
+
+    if args.commit:
+        commit_all(target, "shiki: start project control plane")
+    if args.push:
+        push_branch(target, args.branch)
+
+    output = {
+        "start_id": start_id,
+        "repo": answers["repo"],
+        "project_name": answers["project_name"],
+        "skills_dir": answers["skills_dir"],
+        "plan_id": plan_id,
+        "goal_id": result["goal_id"],
+        "run_id": result["run_id"],
+        "dispatchable_task_ids": result["dispatchable_task_ids"],
+        "issues": issues,
+        "handoffs": handoffs,
+        "start_file": str(start_file),
+        "ledger_id": ledger_id,
+    }
+    print_json(output)
     return 0
 
 
@@ -1871,6 +2182,39 @@ def build_parser() -> argparse.ArgumentParser:
 
     status = subcommands.add_parser("status", help="Show local Shiki CLI configuration")
     status.set_defaults(func=cmd_status)
+
+    start = subcommands.add_parser("start", help="One-command interactive Shiki project setup and first run")
+    start.add_argument("target_positional", nargs="?", help="Target repository path")
+    start.add_argument("--target", default=".", help="Target repository path")
+    start.add_argument("--answers-file", help="JSON answers for non-interactive start")
+    start.add_argument("--repo", help="GitHub repository as OWNER/NAME")
+    start.add_argument("--project-name")
+    start.add_argument("--goal")
+    start.add_argument("--outcome")
+    start.add_argument("--skills-dir", help="Engineering skills directory used by Skill Gate")
+    start.add_argument("--completion-condition", action="append", default=[])
+    start.add_argument("--non-goal", action="append", default=[])
+    start.add_argument("--risk-level", choices=["low", "medium", "high", "critical"])
+    start.add_argument("--required-skill", action="append", default=[])
+    start.add_argument("--task-title")
+    start.add_argument("--task-scope")
+    start.add_argument("--acceptance-check", action="append", default=[])
+    start.add_argument("--lock", action="append", default=[])
+    start.add_argument("--branch", default="main")
+    start.add_argument("--private", action="store_true", help="Create a private repo")
+    start.add_argument("--public", action="store_true", help=argparse.SUPPRESS)
+    start.add_argument("--force", action="store_true", help="Overwrite existing target files during init")
+    start.add_argument("--validate", action=argparse.BooleanOptionalAction, default=True)
+    start.add_argument("--commit", action=argparse.BooleanOptionalAction, default=True)
+    start.add_argument("--commit-message", default="shiki: initialize GitHub-first control plane")
+    start.add_argument("--push", action=argparse.BooleanOptionalAction, default=True)
+    start.add_argument("--set-secret", action=argparse.BooleanOptionalAction, default=True)
+    start.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
+    start.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
+    start.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    start.add_argument("--create-issues", action=argparse.BooleanOptionalAction, default=True)
+    start.add_argument("--create-handoffs", action=argparse.BooleanOptionalAction, default=True)
+    start.set_defaults(func=cmd_start)
 
     plan = subcommands.add_parser("plan", help="Ingest and guide grill-with-docs plans")
     plan_subcommands = plan.add_subparsers(dest="plan_command", required=True)

--- a/scripts/test_shiki_init.sh
+++ b/scripts/test_shiki_init.sh
@@ -23,8 +23,8 @@ python3 scripts/validate_shiki.py
 python3 -m py_compile scripts/shiki.py
 python3 scripts/shiki.py --help | grep -E "init|preflight" >/dev/null
 
-git show HEAD:.claude/commands/shiki.md | grep "shiki init . --repo OWNER/NAME" >/dev/null
-grep "shiki init . --repo OWNER/NAME" .codex/skills/shiki/SKILL.md >/dev/null
+grep "shiki start" .claude/commands/shiki.md >/dev/null
+grep "shiki start" .codex/skills/shiki/SKILL.md >/dev/null
 
 mkdir -p "$TMP_ROOT/missing-repo" "$TMP_ROOT/invalid-repo" "$TMP_ROOT/no-local" "$TMP_ROOT/local-only"
 

--- a/scripts/test_shiki_start.sh
+++ b/scripts/test_shiki_start.sh
@@ -49,6 +49,10 @@ SH
 chmod +x "$FAKE_BIN/gh"
 export PATH="$FAKE_BIN:$PATH"
 export SHIKI_FAKE_GH_LOG="$TMP_ROOT/gh.log"
+export GIT_AUTHOR_NAME="Shiki Test"
+export GIT_AUTHOR_EMAIL="shiki-test@example.local"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
 cat >"$TMP_ROOT/answers.json" <<'JSON'
 {

--- a/scripts/test_shiki_start.sh
+++ b/scripts/test_shiki_start.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/shiki-start-test-$$"
+TARGET="$TMP_ROOT/target"
+FAKE_BIN="$TMP_ROOT/bin"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+json_get() {
+  python3 -c 'import json,sys; text=open(sys.argv[1]).read(); start=text.rfind("\n{"); start = 0 if start == -1 else start + 1; print(json.loads(text[start:])[sys.argv[2]])' "$1" "$2"
+}
+
+cd "$ROOT"
+
+python3 scripts/validate_shiki.py
+python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py
+python3 scripts/shiki.py --help | grep "start" >/dev/null
+
+mkdir -p "$TARGET" "$FAKE_BIN"
+
+cat >"$FAKE_BIN/gh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >>"${SHIKI_FAKE_GH_LOG}"
+case "$1 $2" in
+  "auth status")
+    exit 0
+    ;;
+  "repo view")
+    exit 1
+    ;;
+  "repo create")
+    echo "https://github.com/example/shiki-start-test"
+    exit 0
+    ;;
+  "issue create")
+    echo "https://github.com/example/shiki-start-test/issues/101"
+    exit 0
+    ;;
+esac
+echo "fake gh unsupported: $*" >&2
+exit 1
+SH
+chmod +x "$FAKE_BIN/gh"
+export PATH="$FAKE_BIN:$PATH"
+export SHIKI_FAKE_GH_LOG="$TMP_ROOT/gh.log"
+
+cat >"$TMP_ROOT/answers.json" <<'JSON'
+{
+  "repo": "example/shiki-start-test",
+  "project_name": "Shiki Start Test",
+  "goal": "Ship a one command Shiki start flow",
+  "outcome": "A user can run one command and receive a GitHub-first Shiki project with task evidence",
+  "completion_conditions": [
+    "The first generated task is dispatchable",
+    "A GitHub issue exists for the first task"
+  ],
+  "non_goals": [
+    "Do not require manual shiki init before start",
+    "Do not bypass grill-with-docs"
+  ],
+  "risk_level": "medium",
+  "required_skills": ["grill-with-docs", "to-prd", "to-issues", "tdd"],
+  "tasks": [
+    {
+      "title": "Create one command start path",
+      "scope": "Initialize the repo, persist the grilled plan, run Shiki orchestration, and create the first GitHub issue",
+      "acceptance_checks": ["One command creates Shiki run state and issue evidence"],
+      "locks": ["path:src/start/*"],
+      "required_skills": ["tdd"]
+    }
+  ]
+}
+JSON
+
+python3 scripts/shiki.py start \
+  "$TARGET" \
+  --answers-file "$TMP_ROOT/answers.json" \
+  --no-push \
+  --no-protect \
+  --no-set-secret \
+  >/tmp/shiki-start.json
+
+test -f "$TARGET/.shiki/repo.json"
+test -f "$TARGET/.shiki/plans/P-0001.json"
+test -f "$TARGET/.shiki/runs/RUN-0001.json"
+test -f "$TARGET/.shiki/starts/START-0001.json"
+test -n "$(find "$TARGET/.shiki/tasks" -type f -name 'T-*.json' -print -quit)"
+grep "repo create" "$SHIKI_FAKE_GH_LOG" >/dev/null
+grep "issue create" "$SHIKI_FAKE_GH_LOG" >/dev/null
+
+START_ID="$(json_get /tmp/shiki-start.json start_id)"
+GOAL_ID="$(json_get /tmp/shiki-start.json goal_id)"
+SKILLS_DIR="$(json_get /tmp/shiki-start.json skills_dir)"
+test "$START_ID" = "START-0001"
+test -n "$SKILLS_DIR"
+test -f "$TARGET/.shiki/goals/$GOAL_ID.json"
+
+python3 "$TARGET/scripts/validate_shiki.py"
+
+echo "shiki start tests passed"

--- a/scripts/validate_shiki.py
+++ b/scripts/validate_shiki.py
@@ -21,6 +21,7 @@ RUN_ID = re.compile(r"^RUN-[0-9]{4,}$")
 INBOX_ID = re.compile(r"^INBOX-[0-9]{4,}$")
 EXEC_ID = re.compile(r"^EXEC-[0-9]{4,}$")
 SMOKE_ID = re.compile(r"^SMOKE-[0-9]{4,}$")
+START_ID = re.compile(r"^START-[0-9]{4,}$")
 
 TASK_REQUIRED = {
     "id",
@@ -53,6 +54,20 @@ RUN_REQUIRED = {
 }
 RUNNER_REQUIRED = {"id", "task_id", "goal_id", "command", "returncode", "stdout", "stderr", "created_at"}
 SMOKE_REQUIRED = {"id", "repo", "dry_run", "execute_github", "created_at"}
+START_REQUIRED = {
+    "id",
+    "repo",
+    "project_name",
+    "skills_dir",
+    "questions",
+    "plan_id",
+    "goal_id",
+    "run_id",
+    "dispatchable_task_ids",
+    "issues",
+    "handoffs",
+    "created_at",
+}
 
 RUNTIMES = {
     "codex",
@@ -352,6 +367,36 @@ def validate_smoke(path: Path, data: dict[str, Any]) -> None:
     require_string(path, data, "created_at")
 
 
+def validate_start(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
+    require_keys(path, data, START_REQUIRED)
+    start_id = require_string(path, data, "id")
+    if not START_ID.match(start_id):
+        raise ValidationError(f"{path}: id must match START-0001 style")
+    require_string(path, data, "repo")
+    require_string(path, data, "project_name")
+    require_string(path, data, "skills_dir")
+    questions = require_list(path, data, "questions")
+    if not questions or not all(isinstance(question, str) and question for question in questions):
+        raise ValidationError(f"{path}: questions must be a non-empty list of strings")
+    plan_id = require_string(path, data, "plan_id")
+    if not PLAN_ID.match(plan_id):
+        raise ValidationError(f"{path}: plan_id must match P-0001 style")
+    goal_id = require_string(path, data, "goal_id")
+    if not GOAL_ID.match(goal_id):
+        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    run_id = require_string(path, data, "run_id")
+    if not RUN_ID.match(run_id):
+        raise ValidationError(f"{path}: run_id must match RUN-0001 style")
+    for task_id in require_list(path, data, "dispatchable_task_ids"):
+        if not isinstance(task_id, str) or not TASK_ID.match(task_id):
+            raise ValidationError(f"{path}: dispatchable_task_ids must contain T-0001 style ids")
+        if known_tasks and task_id not in known_tasks:
+            raise ValidationError(f"{path}: dispatchable task {task_id} has no matching task file")
+    require_list(path, data, "issues")
+    require_list(path, data, "handoffs")
+    require_string(path, data, "created_at")
+
+
 def json_files(directory: Path) -> list[Path]:
     if not directory.exists():
         return []
@@ -424,6 +469,12 @@ def main() -> int:
             if not isinstance(data, dict):
                 raise ValidationError(f"{smoke_path}: smoke record must be a JSON object")
             validate_smoke(smoke_path, data)
+
+        for start_path in json_files(SHIKI / "starts"):
+            data = load_json(start_path)
+            if not isinstance(data, dict):
+                raise ValidationError(f"{start_path}: start record must be a JSON object")
+            validate_start(start_path, data, known_tasks)
 
     except ValidationError as error:
         errors.append(str(error))


### PR DESCRIPTION
## Goal
- G-0001

## Task
- T-0010 Make /shiki a one-command guided start flow

## Scope
- Add `shiki start` as the normal guided one-command entrypoint.
- Let `/shiki` ask missing repo and Goal values one question at a time, then run `shiki start`.
- Initialize GitHub-first target repos, persist a grilled plan, run orchestration, create the first GitHub issue, write handoff and start evidence, commit, and push.
- Record the selected engineering Skill Gate directory, defaulting to `/Users/kio.mizutani/Documents/lead-os/skills/engineering` when present.

## Non-goals
- Do not remove lower-level init, plan, run, daemon, runner, or smoke commands.
- Do not create real GitHub repos in tests.
- Do not bypass branch protection.

## Acceptance
- `shiki start /path/to/repo --repo OWNER/REPO --goal ... --outcome ...` is supported.
- `/shiki` docs and Codex skill route users to `shiki start`, not manual multi-command setup.
- Start records validate under `.shiki/starts/*.json`.
- CI runs the one-command start contract test.

## Locks
- `path:scripts/shiki.py`
- `path:scripts/validate_shiki.py`
- `path:scripts/test_shiki_start.sh`
- `path:.github/workflows/shiki-validate.yml`
- `path:.claude/commands/shiki.md`
- `path:.codex/skills/shiki/SKILL.md`
- `path:docs/agents/bootstrap-command.md`
- `path:docs/agents/control-commands.md`
- `path:.shiki/schemas/start.schema.json`
- `path:.shiki/tasks/T-0009.json`
- `path:.shiki/tasks/T-0010.json`
- `path:.shiki/ledger/L-0014.json`
- `path:.shiki/ledger/L-0015.json`
- `path:.shiki/ledger/L-0016.json`
- `path:.shiki/ledger/L-0017.json`

## Risk level
- medium

## CCA checklist profile
- PR
- TDD
- V
- CCA
- MG

## Evidence
- `python3 scripts/validate_shiki.py` passed.
- `python3 -m py_compile scripts/shiki.py scripts/validate_shiki.py` passed.
- `bash scripts/test_shiki_start.sh` passed.
- `bash scripts/test_shiki_init.sh` passed.
- `bash scripts/test_shiki_control_plane.sh` passed.
- `bash scripts/test_shiki_run_orchestrator.sh` passed.
- `bash scripts/test_shiki_daemon_runner.sh` passed.
- Workflow YAML parse check passed.
- `git diff --check` passed.

## Ledger Evidence
- `.shiki/tasks/T-0010.json`
- `.shiki/ledger/L-0014.json`
- `.shiki/ledger/L-0015.json`
- `.shiki/ledger/L-0016.json`
- `.shiki/ledger/L-0017.json`

## MergeGate
- Required checks must pass.
- CCA verdict must be complete.
- MergeGate policy check must pass.
