### PR TITLE
chore: record Shiki start completion

### DIFF
--- a/.shiki/ledger/L-0018.json
+++ b/.shiki/ledger/L-0018.json
@@ -1,0 +1,17 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    ".shiki/tasks/T-0010.json",
+    "https://github.com/mizutani-140/shiki/pull/17",
+    "merge commit 8691d2e"
+  ],
+  "goal_id": "G-0001",
+  "id": "L-0018",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/17"
+  ],
+  "summary": "Completed T-0010 after PR #17 passed Validate Shiki mirror, Claude review, CCA verdict, MergeGate metadata check, and MergeGate policy check, then merged to main.",
+  "task_id": "T-0010",
+  "timestamp": "2026-05-29T07:38:07+00:00",
+  "type": "completion"
+}

--- a/.shiki/tasks/T-0010.json
+++ b/.shiki/tasks/T-0010.json
@@ -28,7 +28,8 @@
     "path:.shiki/ledger/L-0014.json",
     "path:.shiki/ledger/L-0015.json",
     "path:.shiki/ledger/L-0016.json",
-    "path:.shiki/ledger/L-0017.json"
+    "path:.shiki/ledger/L-0017.json",
+    "path:.shiki/ledger/L-0018.json"
   ],
   "assigned_runtime": "codex-front",
   "risk_level": "medium",
@@ -53,7 +54,8 @@
   "ledger_evidence": [
     "L-0014",
     "L-0016",
-    "L-0017"
+    "L-0017",
+    "L-0018"
   ],
-  "status": "review"
+  "status": "done"
 }


### PR DESCRIPTION
## Goal
- G-0001

## Task
- T-0010 Make /shiki a one-command guided start flow

## Scope
- Record post-merge completion evidence for PR #17.
- Mark T-0010 as done in the Shiki mirror.

## Non-goals
- No product or CLI behavior changes.
- No branch protection bypass.

## Acceptance
- T-0010 status is `done` in `.shiki/tasks/T-0010.json`.
- Completion ledger `L-0018` records PR #17 checks and merge evidence.
- Shiki mirror validation passes.

## Locks
- `path:.shiki/tasks/T-0010.json`
- `path:.shiki/ledger/L-0018.json`

## Risk level
- low

## CCA checklist profile
- PR
- V
- CCA
- MG

## Evidence
- PR #17 passed Validate Shiki mirror, Claude review, CCA verdict, MergeGate metadata check, and MergeGate policy check.
- PR #17 merged as merge commit `8691d2e`.
- `python3 scripts/validate_shiki.py` passed locally.
- `git diff --check` passed locally.

## Ledger Evidence
- `.shiki/ledger/L-0018.json`
- `.shiki/tasks/T-0010.json`

## MergeGate
- Required checks must pass.
- CCA verdict must be complete.
- MergeGate policy check must pass.
