### PR TITLE
shiki: reconcile T-0023 post-merge mirror

### DIFF
--- a/.shiki/goals/G-0012.json
+++ b/.shiki/goals/G-0012.json
@@ -23,8 +23,11 @@
   "id": "G-0012",
   "ledger_evidence": [
     "L-0076",
-        "L-0094",
-        "L-0100"
+    "L-0094",
+    "L-0100",
+    "L-0101",
+    "L-0102",
+    "L-0103"
   ],
   "non_goals": [
     "Do not add unrelated product features.",

--- a/.shiki/ledger/L-0103.json
+++ b/.shiki/ledger/L-0103.json
@@ -1,0 +1,28 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    "PR #39 was merged into main at merge commit 017bba2.",
+    "CCA verdict passed.",
+    "CCA Review Bridge created an APPROVED GitHub review using the GitHub Actions identity.",
+    "MergeGate policy check passed.",
+    "MergeGate metadata check passed.",
+    "Validate Shiki mirror passed.",
+    "Claude review passed.",
+    "T-0023 status is set to done.",
+    "T-0023 active locks are absent.",
+    "Issue #33 is ready to be closed as complete.",
+    "Goal #30 P0.3 progress is ready to be updated, except branch-protection approval-count and CODEOWNERS/governance items that remain open until separately proven."
+  ],
+  "goal_id": "G-0012",
+  "id": "L-0103",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/39",
+    "https://github.com/mizutani-140/shiki/commit/017bba2",
+    "https://github.com/mizutani-140/shiki/issues/33",
+    "https://github.com/mizutani-140/shiki/issues/30"
+  ],
+  "summary": "Recorded T-0023 post-merge completion and released task state after PR #39 merge.",
+  "task_id": "T-0023",
+  "timestamp": "2026-06-02T08:34:46Z",
+  "type": "completion"
+}

--- a/.shiki/ledger/L-0103.json
+++ b/.shiki/ledger/L-0103.json
@@ -2,6 +2,7 @@
   "actor": "codex-front",
   "evidence": [
     "PR #39 was merged into main at merge commit 017bba2.",
+    "PR #40 records the bounded post-merge mirror reconciliation for T-0023.",
     "CCA verdict passed.",
     "CCA Review Bridge created an APPROVED GitHub review using the GitHub Actions identity.",
     "MergeGate policy check passed.",
@@ -17,6 +18,7 @@
   "id": "L-0103",
   "links": [
     "https://github.com/mizutani-140/shiki/pull/39",
+    "https://github.com/mizutani-140/shiki/pull/40",
     "https://github.com/mizutani-140/shiki/commit/017bba2",
     "https://github.com/mizutani-140/shiki/issues/33",
     "https://github.com/mizutani-140/shiki/issues/30"

--- a/.shiki/tasks/T-0023.json
+++ b/.shiki/tasks/T-0023.json
@@ -21,7 +21,8 @@
   "ledger_evidence": [
     "L-0079",
     "L-0101",
-    "L-0102"
+    "L-0102",
+    "L-0103"
   ],
   "locks": [
     "path:.shiki/config.yaml",
@@ -35,7 +36,8 @@
     "path:docs/agents/**",
     "path:.shiki/tasks/T-0023.json",
     "path:.shiki/ledger/L-0101.json",
-    "path:.shiki/ledger/L-0102.json"
+    "path:.shiki/ledger/L-0102.json",
+    "path:.shiki/ledger/L-0103.json"
   ],
   "non_goals": [
     "Do not weaken CCA or MergeGate to make PRs easier to merge."
@@ -47,6 +49,6 @@
   ],
   "risk_level": "critical",
   "scope": "Make required checks single-source, ensure required_review is enforced by GitHub branch protection, separate advisory AI review from blocking review, and make Guardian approval machine-readable.",
-  "status": "review",
+  "status": "done",
   "title": "Enforce MergeGate, review, branch protection, and Guardian rules"
 }

--- a/.shiki/tasks/T-0023.json
+++ b/.shiki/tasks/T-0023.json
@@ -13,8 +13,8 @@
   "dependencies": [
     "T-0021"
   ],
-  "expected_branch": "shiki/t-0023-enforce-mergegate-review-branch-protection-and-g",
-  "expected_pr": 39,
+  "expected_branch": "reconcile-t0023-post-merge",
+  "expected_pr": 40,
   "github_issue": 33,
   "goal_id": "G-0012",
   "id": "T-0023",
@@ -34,6 +34,7 @@
     "path:.github/pull_request_template.md",
     "path:CODEOWNERS",
     "path:docs/agents/**",
+    "path:.shiki/goals/G-0012.json",
     "path:.shiki/tasks/T-0023.json",
     "path:.shiki/ledger/L-0101.json",
     "path:.shiki/ledger/L-0102.json",


### PR DESCRIPTION
## Shiki Task

- Goal: G-0012
- Task: T-0023 post-merge reconciliation
- Issue: #33
- Runtime: codex
- Risk: critical

## Scope

- Mark `.shiki/tasks/T-0023.json` as `done` after PR #39 merged.
- Add `L-0103` as post-merge completion ledger evidence.
- Connect `L-0101`, `L-0102`, and `L-0103` to `.shiki/goals/G-0012.json`.
- Confirm no `.shiki/locks/T-0023.json` file exists locally.

## Non-Goals

- Do not change implementation code.
- Do not change workflows.
- Do not broaden into T-0024, T-0026, branch-protection payload changes, or CODEOWNERS governance.
- Do not close Issue #33 until this reconciliation PR is merged.

## Evidence

- PR #39 merged into `main` at `017bba2`.
- CCA verdict passed.
- CCA Review Bridge created an APPROVED GitHub review.
- MergeGate policy check passed.
- MergeGate metadata check passed.
- Validate Shiki mirror passed.
- Claude review passed.
- Ledger: `L-0101`, `L-0102`, `L-0103`.

## Acceptance

- T-0023 mirror status is `done`.
- T-0023 ledger evidence includes `L-0101`, `L-0102`, and `L-0103`.
- Goal `G-0012` ledger evidence includes `L-0101`, `L-0102`, and `L-0103`.
- T-0023 active locks are released or absent.
- No implementation code or workflow behavior changes are included.

## Verification

- [x] `python3 scripts/validate_shiki.py`
- [x] `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 -m py_compile scripts/*.py`
- [x] `for script in scripts/test_shiki_*.sh; do PYTHONPYCACHEPREFIX=/tmp/shiki-pycache bash "$script"; done`
- [x] `git diff --check`

## Follow-Up After Merge

- Comment on and close Issue #33 as T-0023 complete.
- Update Goal #30 P0.3 items covered by T-0023.
- Leave P0.3.5 open unless branch protection payload requires at least one approving review.
- Leave P0.3.7 open unless CODEOWNERS or equivalent machine-checkable governance exists.
