### PR TITLE
shiki: enforce branch protection review count

### DIFF
--- a/.shiki/ledger/L-0104.json
+++ b/.shiki/ledger/L-0104.json
@@ -3,6 +3,7 @@
   "evidence": [
     "Added branch protection review-count derivation from .shiki/config.yaml defaults.required_review.",
     "Configured required_review=true to produce required_approving_review_count >= 1.",
+    "TDD evidence: added regression tests before final verification for required_review=true and required_review=false branch protection review-count behavior.",
     "Added regression coverage for required_review=true and required_review=false branch protection behavior.",
     "Documented the interaction between branch protection, required_review, and the CCA Review Bridge.",
     "Scope is limited to Goal #30 P0.3.5; CODEOWNERS governance remains separate."

--- a/.shiki/ledger/L-0104.json
+++ b/.shiki/ledger/L-0104.json
@@ -1,0 +1,19 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    "Added branch protection review-count derivation from .shiki/config.yaml defaults.required_review.",
+    "Configured required_review=true to produce required_approving_review_count >= 1.",
+    "Added regression coverage for required_review=true and required_review=false branch protection behavior.",
+    "Documented the interaction between branch protection, required_review, and the CCA Review Bridge.",
+    "Scope is limited to Goal #30 P0.3.5; CODEOWNERS governance remains separate."
+  ],
+  "goal_id": "G-0012",
+  "id": "L-0104",
+  "links": [
+    "https://github.com/mizutani-140/shiki/issues/30"
+  ],
+  "summary": "Implemented P0.3.5 branch protection approval-count enforcement.",
+  "task_id": "T-0031",
+  "timestamp": "2026-06-02T09:29:51Z",
+  "type": "check"
+}

--- a/.shiki/ledger/L-0104.json
+++ b/.shiki/ledger/L-0104.json
@@ -6,11 +6,13 @@
     "TDD evidence: added regression tests before final verification for required_review=true and required_review=false branch protection review-count behavior.",
     "Added regression coverage for required_review=true and required_review=false branch protection behavior.",
     "Documented the interaction between branch protection, required_review, and the CCA Review Bridge.",
+    "PR #42 carries the T-0031 implementation and bounded repair evidence.",
     "Scope is limited to Goal #30 P0.3.5; CODEOWNERS governance remains separate."
   ],
   "goal_id": "G-0012",
   "id": "L-0104",
   "links": [
+    "https://github.com/mizutani-140/shiki/pull/42",
     "https://github.com/mizutani-140/shiki/issues/30"
   ],
   "summary": "Implemented P0.3.5 branch protection approval-count enforcement.",

--- a/.shiki/tasks/T-0031.json
+++ b/.shiki/tasks/T-0031.json
@@ -11,7 +11,7 @@
     "T-0023"
   ],
   "expected_branch": "shiki/t-0031-enforce-branch-protection-review-count",
-  "expected_pr": null,
+  "expected_pr": 42,
   "github_issue": 41,
   "goal_id": "G-0012",
   "id": "T-0031",

--- a/.shiki/tasks/T-0031.json
+++ b/.shiki/tasks/T-0031.json
@@ -1,0 +1,41 @@
+{
+  "acceptance_checks": [
+    "protect_branch() no longer emits required_approving_review_count: 0 when required_review is true.",
+    "Required review count is derived from .shiki/config.yaml defaults.required_review.",
+    "Tests prove required_review=true leads to required_approving_review_count >= 1.",
+    "Tests prove required_review=false does not force an approving review.",
+    "Docs explain interaction between GitHub branch protection, CCA Review Bridge, and required_review."
+  ],
+  "assigned_runtime": "codex",
+  "dependencies": [
+    "T-0023"
+  ],
+  "expected_branch": "shiki/t-0031-enforce-branch-protection-review-count",
+  "expected_pr": null,
+  "github_issue": 41,
+  "goal_id": "G-0012",
+  "id": "T-0031",
+  "ledger_evidence": [
+    "L-0104"
+  ],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/test_shiki_init.sh",
+    "path:docs/agents/decision-control.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:.shiki/tasks/T-0031.json",
+    "path:.shiki/ledger/L-0104.json"
+  ],
+  "non_goals": [
+    "Do not weaken MergeGate.",
+    "Do not remove CCA Review Bridge.",
+    "Do not broaden into CODEOWNERS governance."
+  ],
+  "required_skills": [
+    "tdd"
+  ],
+  "risk_level": "critical",
+  "scope": "Close Goal #30 P0.3.5 by making Shiki branch protection require at least one approving review whenever .shiki/config.yaml has defaults.required_review: true.",
+  "status": "review",
+  "title": "Enforce required review count in branch protection payload"
+}

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -191,6 +191,9 @@ The bootstrap command attempts to require:
 
 - `Validate Shiki mirror`
 - `CCA verdict`
+- `MergeGate metadata check`
 - `MergeGate policy check`
+
+When `.shiki/config.yaml` sets `defaults.required_review: true`, the bootstrap command configures branch protection with at least one required approving PR review. Solo/self-running operation relies on the CCA Review Bridge to create that GitHub review only after CCA completes and Guardian evidence is present when required.
 
 If the GitHub API rejects branch protection because of plan or permission limits, configure these checks manually in branch protection or rulesets.

--- a/docs/agents/decision-control.md
+++ b/docs/agents/decision-control.md
@@ -155,6 +155,8 @@ The CCA Review Bridge is not advisory Claude review and is not Guardian approval
 
 The bridge uses REST PR review creation after CCA verdict enforcement succeeds. If the repository's `GITHUB_TOKEN` cannot create approvals even when `can_approve_pull_request_reviews=true`, configure a non-author reviewer bot token or GitHub App installation token with `Pull requests: write`; do not weaken `required_review` or substitute advisory Claude review.
 
+When `.shiki/config.yaml` sets `defaults.required_review: true`, Shiki branch protection must require at least one approving PR review. The CCA Review Bridge is the automation path that can satisfy that GitHub review requirement in solo operation after CCA and Guardian gates have already passed; it does not replace MergeGate policy or Guardian evidence.
+
 ### CD Gate
 
 Deployment requires a separate gate from merge. Merge means the code can enter the protected branch. Deploy means the code can affect an environment.

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -181,6 +181,66 @@ def github_repo_exists(repo: str) -> bool:
     return run(["gh", "repo", "view", repo, "--json", "name"], check=False).returncode == 0
 
 
+def parse_config_scalar(value: str) -> Any:
+    value = value.strip().strip("\"'")
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    return value
+
+
+def load_shiki_config(target: Path) -> dict[str, dict[str, Any]]:
+    """Read the small .shiki/config.yaml subset bootstrap owns."""
+    config_path = target / ".shiki" / "config.yaml"
+    if not config_path.exists():
+        return {}
+
+    config: dict[str, dict[str, Any]] = {}
+    section: str | None = None
+    key: str | None = None
+    for raw_line in config_path.read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+        if indent == 0:
+            section = stripped[:-1] if stripped.endswith(":") else None
+            key = None
+            if section:
+                config.setdefault(section, {})
+            continue
+        if section is None:
+            continue
+        if indent == 2:
+            if stripped.endswith(":"):
+                key = stripped[:-1]
+                config[section].setdefault(key, [])
+                continue
+            if ":" in stripped:
+                item_key, value = stripped.split(":", 1)
+                config[section][item_key.strip()] = parse_config_scalar(value)
+                key = None
+                continue
+        if indent >= 4 and key and stripped.startswith("- "):
+            values = config[section].setdefault(key, [])
+            if isinstance(values, list):
+                values.append(parse_config_scalar(stripped[2:]))
+    return config
+
+
+def configured_required_review(target: Path) -> bool:
+    value = load_shiki_config(target).get("defaults", {}).get("required_review")
+    if isinstance(value, bool):
+        return value
+    return True
+
+
+def branch_protection_review_count(target: Path) -> int:
+    return 1 if configured_required_review(target) else 0
+
+
 def ensure_github_repo(repo: str, visibility: str) -> None:
     if github_repo_exists(repo):
         info(f"GitHub repository already exists: {repo}")
@@ -289,7 +349,7 @@ def github_secret_status(repo: str, secret_name: str) -> dict[str, Any]:
     }
 
 
-def protect_branch(repo: str, branch: str, required_checks: list[str]) -> None:
+def protect_branch(repo: str, branch: str, required_checks: list[str], *, review_count: int) -> None:
     payload = {
         "required_status_checks": {
             "strict": True,
@@ -299,7 +359,7 @@ def protect_branch(repo: str, branch: str, required_checks: list[str]) -> None:
         "required_pull_request_reviews": {
             "dismiss_stale_reviews": True,
             "require_code_owner_reviews": False,
-            "required_approving_review_count": 0,
+            "required_approving_review_count": review_count,
         },
         "restrictions": None,
         "required_conversation_resolution": True,
@@ -2103,7 +2163,7 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
     configure_claude_code_secret(repo, enabled=args.set_secret, secret_env=args.secret_env)
 
     if args.protect:
-        protect_branch(repo, branch, args.required_check)
+        protect_branch(repo, branch, args.required_check, review_count=branch_protection_review_count(ROOT))
 
     save_default_config(repo, branch)
     info("bootstrap complete")
@@ -2176,7 +2236,7 @@ def cmd_init(args: argparse.Namespace) -> int:
     configure_claude_code_secret(repo, enabled=args.set_secret, secret_env=args.secret_env)
 
     if args.protect:
-        protect_branch(repo, branch, args.required_check)
+        protect_branch(repo, branch, args.required_check, review_count=branch_protection_review_count(target))
 
     info("GitHub-first init complete")
     return 0

--- a/scripts/test_shiki_init.sh
+++ b/scripts/test_shiki_init.sh
@@ -28,6 +28,7 @@ grep "shiki start" .claude/commands/shiki.md >/dev/null
 grep "shiki start" .codex/skills/shiki/SKILL.md >/dev/null
 
 mkdir -p "$TMP_ROOT/missing-repo" "$TMP_ROOT/invalid-repo" "$TMP_ROOT/no-local" "$TMP_ROOT/local-only" "$FAKE_BIN"
+export TMP_ROOT
 
 cat >"$FAKE_BIN/gh" <<'SH'
 #!/usr/bin/env bash
@@ -53,7 +54,7 @@ case "$1 $2" in
     exit 1
     ;;
   "api repos/"*)
-    cat >/dev/null
+    cat >"${SHIKI_FAKE_GH_PAYLOAD:-/dev/null}"
     exit 0
     ;;
 esac
@@ -134,5 +135,46 @@ expect_fail python3 scripts/shiki.py init "$PROTECT_FAIL" \
   --no-commit \
   --no-push
 grep "could not configure branch protection" /tmp/shiki-expected-fail.out >/dev/null
+
+CONFIG_FALSE="$TMP_ROOT/config-false"
+mkdir -p "$CONFIG_FALSE/.shiki"
+cat >"$CONFIG_FALSE/.shiki/config.yaml" <<'YAML'
+defaults:
+  required_review: false
+YAML
+python3 - <<'PY'
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path.cwd() / "scripts"))
+import shiki
+
+root = Path(os.environ["TMP_ROOT"])
+if shiki.branch_protection_review_count(Path.cwd()) < 1:
+    raise SystemExit("required_review=true must require at least one approving review")
+if shiki.branch_protection_review_count(root / "config-false") != 0:
+    raise SystemExit("required_review=false must not force an approving review")
+PY
+
+PROTECT_PASS="$TMP_ROOT/protect-pass"
+mkdir -p "$PROTECT_PASS"
+export SHIKI_FAKE_GH_PAYLOAD="$TMP_ROOT/protect-payload.json"
+python3 scripts/shiki.py init "$PROTECT_PASS" \
+  --repo example/shiki-init-protect-pass \
+  --no-commit \
+  --no-push >/tmp/shiki-init-protect-pass.out
+python3 - "$SHIKI_FAKE_GH_PAYLOAD" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+count = payload["required_pull_request_reviews"]["required_approving_review_count"]
+if count < 1:
+    raise SystemExit(f"expected required_approving_review_count >= 1, got {count}")
+contexts = payload["required_status_checks"]["contexts"]
+if "MergeGate metadata check" not in contexts or "MergeGate policy check" not in contexts:
+    raise SystemExit(f"branch protection contexts missing MergeGate checks: {contexts}")
+PY
 
 echo "shiki init tests passed"


### PR DESCRIPTION
## Shiki Task

- Goal: G-0012 / Issue #30
- Task: T-0031
- Issue: #41
- Runtime: codex
- Risk: critical

## Scope

Close Goal #30 P0.3.5 by making Shiki branch protection require at least one approving review whenever `.shiki/config.yaml` has `defaults.required_review: true`.

## Non-Goals

- Do not weaken MergeGate.
- Do not remove CCA Review Bridge.
- Do not disable required review.
- Do not broaden into CODEOWNERS governance.
- Do not change unrelated bootstrap behavior.

## Locks

- path:scripts/shiki.py
- path:scripts/test_shiki_init.sh
- path:docs/agents/decision-control.md
- path:docs/agents/bootstrap-command.md
- path:.shiki/tasks/T-0031.json
- path:.shiki/ledger/L-0104.json

## Acceptance Checks

- `protect_branch()` no longer emits `required_approving_review_count: 0` when `required_review: true`.
- Required review count is derived from `.shiki/config.yaml` defaults.
- Tests prove `required_review=true` leads to `required_approving_review_count >= 1`.
- Tests prove `required_review=false` does not force an approving review.
- Docs explain interaction between GitHub branch protection, CCA Review Bridge, and `can_approve_pull_request_reviews=true`.

## Verification

- [x] `python3 scripts/validate_shiki.py` - passed.
- [x] `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 -m py_compile scripts/*.py` - passed.
- [x] `for script in scripts/test_shiki_*.sh; do PYTHONPYCACHEPREFIX=/tmp/shiki-pycache bash "$script"; done` - passed.
- [x] `git diff --check` - passed.

## Evidence

- Branch: `shiki/t-0031-enforce-branch-protection-review-count`
- Commit: `63957be`
- Ledger: `L-0104`
- Issue: #41

## MergeGate

- [x] Dependencies are complete or not required.
- [x] Locks are registered and non-conflicting.
- [x] Required local checks passed.
- [ ] CCA verdict is complete.
- [ ] Required review is complete.
- [x] Ledger evidence is complete for local implementation.
- [ ] High-risk or critical changes have Guardian approval.

Closes #41