### PR TITLE
shiki: add CODEOWNERS governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Critical Shiki governance paths require Guardian owner review.
+/.shiki/config.yaml @mizutani-140
+/.shiki/policy.example.yaml @mizutani-140
+/.github/CODEOWNERS @mizutani-140
+/.github/pull_request_template.md @mizutani-140
+/.github/PULL_REQUEST_TEMPLATE/* @mizutani-140
+/.github/prompts/* @mizutani-140
+/.github/workflows/* @mizutani-140
+/scripts/shiki.py @mizutani-140
+/scripts/mergegate_check.py @mizutani-140
+/scripts/enforce_cca_verdict.py @mizutani-140
+/scripts/validate_shiki.py @mizutani-140
+/scripts/shiki_contracts.py @mizutani-140
+/AGENTS.md @mizutani-140
+/SYSTEM_PROMPT.md @mizutani-140
+/CLAUDE.md @mizutani-140

--- a/.shiki/ledger/L-0106.json
+++ b/.shiki/ledger/L-0106.json
@@ -11,6 +11,7 @@
   "goal_id": "G-0012",
   "id": "L-0106",
   "links": [
+    "https://github.com/mizutani-140/shiki/pull/45",
     "https://github.com/mizutani-140/shiki/issues/44",
     "https://github.com/mizutani-140/shiki/issues/30"
   ],

--- a/.shiki/ledger/L-0106.json
+++ b/.shiki/ledger/L-0106.json
@@ -1,0 +1,21 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    "Added .github/CODEOWNERS for critical Shiki governance paths.",
+    "Configured branch protection payload to require code owner reviews.",
+    "Added validator coverage for required CODEOWNERS rules and owner.",
+    "TDD evidence: added regression coverage for CODEOWNERS presence, validator wiring, template install, and branch protection require_code_owner_reviews payload behavior.",
+    "Documented CODEOWNERS governance as separate from advisory Claude review, Guardian approval evidence, and the CCA Review Bridge.",
+    "P0.3.7 scope is limited to CODEOWNERS or equivalent machine-checkable governance."
+  ],
+  "goal_id": "G-0012",
+  "id": "L-0106",
+  "links": [
+    "https://github.com/mizutani-140/shiki/issues/44",
+    "https://github.com/mizutani-140/shiki/issues/30"
+  ],
+  "summary": "Implemented P0.3.7 CODEOWNERS governance for critical Shiki paths.",
+  "task_id": "T-0032",
+  "timestamp": "2026-06-02T11:00:07Z",
+  "type": "check"
+}

--- a/.shiki/tasks/T-0032.json
+++ b/.shiki/tasks/T-0032.json
@@ -1,0 +1,47 @@
+{
+  "acceptance_checks": [
+    ".github/CODEOWNERS exists.",
+    "Critical Shiki governance paths require configured owner review.",
+    "Branch protection enables code owner reviews when Shiki config requires review.",
+    "Validator fails if CODEOWNERS is missing or does not cover critical paths.",
+    "Tests prove branch protection payload uses require_code_owner_reviews: true.",
+    "Docs explain CODEOWNERS governance and its separation from CCA Review Bridge."
+  ],
+  "assigned_runtime": "codex",
+  "dependencies": [
+    "T-0023",
+    "T-0031"
+  ],
+  "expected_branch": "shiki/t-0032-codeowners-governance",
+  "expected_pr": null,
+  "github_issue": 44,
+  "goal_id": "G-0012",
+  "id": "T-0032",
+  "ledger_evidence": [
+    "L-0106"
+  ],
+  "locks": [
+    "path:.github/CODEOWNERS",
+    "path:scripts/shiki.py",
+    "path:scripts/shiki_contracts.py",
+    "path:scripts/validate_shiki.py",
+    "path:scripts/test_shiki_init.sh",
+    "path:scripts/test_shiki_control_plane.sh",
+    "path:docs/agents/decision-control.md",
+    "path:docs/agents/bootstrap-command.md",
+    "path:.shiki/tasks/T-0032.json",
+    "path:.shiki/ledger/L-0106.json"
+  ],
+  "non_goals": [
+    "Do not change runtime adapter behavior.",
+    "Do not implement P0.2.1 dry-run / execute gating.",
+    "Do not mark P0.4 state and evidence integrity items complete."
+  ],
+  "required_skills": [
+    "tdd"
+  ],
+  "risk_level": "critical",
+  "scope": "Close Goal #30 P0.3.7 by adding CODEOWNERS governance for critical Shiki paths, enforcing code owner review in branch protection, and validating CODEOWNERS coverage.",
+  "status": "review",
+  "title": "Add CODEOWNERS governance for critical Shiki paths"
+}

--- a/.shiki/tasks/T-0032.json
+++ b/.shiki/tasks/T-0032.json
@@ -13,7 +13,7 @@
     "T-0031"
   ],
   "expected_branch": "shiki/t-0032-codeowners-governance",
-  "expected_pr": null,
+  "expected_pr": 45,
   "github_issue": 44,
   "goal_id": "G-0012",
   "id": "T-0032",

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -196,4 +196,6 @@ The bootstrap command attempts to require:
 
 When `.shiki/config.yaml` sets `defaults.required_review: true`, the bootstrap command configures branch protection with at least one required approving PR review. Solo/self-running operation relies on the CCA Review Bridge to create that GitHub review only after CCA completes and Guardian evidence is present when required.
 
+Branch protection also enables code owner review enforcement for critical Shiki governance paths covered by `.github/CODEOWNERS`.
+
 If the GitHub API rejects branch protection because of plan or permission limits, configure these checks manually in branch protection or rulesets.

--- a/docs/agents/decision-control.md
+++ b/docs/agents/decision-control.md
@@ -157,6 +157,12 @@ The bridge uses REST PR review creation after CCA verdict enforcement succeeds. 
 
 When `.shiki/config.yaml` sets `defaults.required_review: true`, Shiki branch protection must require at least one approving PR review. The CCA Review Bridge is the automation path that can satisfy that GitHub review requirement in solo operation after CCA and Guardian gates have already passed; it does not replace MergeGate policy or Guardian evidence.
 
+### CODEOWNERS Governance
+
+Critical Shiki governance paths are covered by `.github/CODEOWNERS` and owned by the configured Guardian owner. Branch protection must require code owner reviews so changes to workflows, MergeGate, CCA, bootstrap, core contracts, and root agent instructions receive machine-checkable owner review.
+
+CODEOWNERS review is separate from advisory Claude review, Guardian approval evidence, and the CCA Review Bridge. The bridge may create the required GitHub review after CCA completes, but it does not replace path-owner governance for critical files.
+
 ### CD Gate
 
 Deployment requires a separate gate from merge. Merge means the code can enter the protected branch. Deploy means the code can affect an environment.

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -37,6 +37,7 @@ TEMPLATE_PATHS = [
     ".codex/skills/shiki/SKILL.md",
     ".shiki",
     ".github/ISSUE_TEMPLATE",
+    ".github/CODEOWNERS",
     ".github/PULL_REQUEST_TEMPLATE",
     ".github/prompts",
     ".github/workflows/shiki-validate.yml",
@@ -358,7 +359,7 @@ def protect_branch(repo: str, branch: str, required_checks: list[str], *, review
         "enforce_admins": True,
         "required_pull_request_reviews": {
             "dismiss_stale_reviews": True,
-            "require_code_owner_reviews": False,
+            "require_code_owner_reviews": review_count > 0,
             "required_approving_review_count": review_count,
         },
         "restrictions": None,

--- a/scripts/shiki_contracts.py
+++ b/scripts/shiki_contracts.py
@@ -19,6 +19,26 @@ DEFAULT_REQUIRED_CHECKS = (
     "MergeGate policy check",
 )
 
+CODEOWNERS_PATH = ".github/CODEOWNERS"
+CODEOWNERS_REQUIRED_OWNER = "@mizutani-140"
+CODEOWNERS_CRITICAL_PATHS = (
+    "/.shiki/config.yaml",
+    "/.shiki/policy.example.yaml",
+    "/.github/CODEOWNERS",
+    "/.github/pull_request_template.md",
+    "/.github/PULL_REQUEST_TEMPLATE/*",
+    "/.github/prompts/*",
+    "/.github/workflows/*",
+    "/scripts/shiki.py",
+    "/scripts/mergegate_check.py",
+    "/scripts/enforce_cca_verdict.py",
+    "/scripts/validate_shiki.py",
+    "/scripts/shiki_contracts.py",
+    "/AGENTS.md",
+    "/SYSTEM_PROMPT.md",
+    "/CLAUDE.md",
+)
+
 RUNTIME_NAMES = (
     "codex",
     "codex-front",

--- a/scripts/test_shiki_control_plane.sh
+++ b/scripts/test_shiki_control_plane.sh
@@ -50,6 +50,11 @@ grep "gh pr create" .github/workflows/shiki-orchestrator.yml >/dev/null
 grep "CANONICAL_CCA_VERDICT_SCHEMA_PATH" scripts/shiki_contracts.py >/dev/null
 grep "CANONICAL_REPAIR_PACKET_SCHEMA_PATH" scripts/shiki_contracts.py >/dev/null
 grep "CANONICAL_SOURCE_OF_TRUTH_ORDER" scripts/shiki_contracts.py >/dev/null
+grep "CODEOWNERS_CRITICAL_PATHS" scripts/shiki_contracts.py >/dev/null
+grep "validate_codeowners_governance" scripts/validate_shiki.py >/dev/null
+grep -F "/.github/workflows/* @mizutani-140" .github/CODEOWNERS >/dev/null
+grep -F "/scripts/mergegate_check.py @mizutani-140" .github/CODEOWNERS >/dev/null
+grep -F "/AGENTS.md @mizutani-140" .github/CODEOWNERS >/dev/null
 grep ".shiki/schemas/cca-verdict.schema.json" AGENTS.md SYSTEM_PROMPT.md CLAUDE.md >/dev/null
 if grep -R ".shiki/templates/cca-verdict.schema.json" AGENTS.md SYSTEM_PROMPT.md CLAUDE.md .codex .claude .github/prompts docs/agents skills/engineering >/tmp/shiki-obsolete-schema-paths.out; then
   cat /tmp/shiki-obsolete-schema-paths.out >&2
@@ -99,6 +104,7 @@ grep "CCA verdict complete" /tmp/shiki-cca-valid-complete.out >/dev/null
 
 mkdir -p "$TARGET"
 python3 scripts/shiki.py install-target "$TARGET" --local-only >/tmp/shiki-control-install.out
+test -f "$TARGET/.github/CODEOWNERS"
 test -f "$TARGET/skills/engineering/shiki/SKILL.md"
 test -f "$TARGET/skills/engineering/grill-with-docs/SKILL.md"
 

--- a/scripts/test_shiki_init.sh
+++ b/scripts/test_shiki_init.sh
@@ -169,12 +169,41 @@ import json
 import sys
 
 payload = json.load(open(sys.argv[1], encoding="utf-8"))
+if payload["required_pull_request_reviews"]["require_code_owner_reviews"] is not True:
+    raise SystemExit("expected require_code_owner_reviews to be true")
 count = payload["required_pull_request_reviews"]["required_approving_review_count"]
 if count < 1:
     raise SystemExit(f"expected required_approving_review_count >= 1, got {count}")
 contexts = payload["required_status_checks"]["contexts"]
 if "MergeGate metadata check" not in contexts or "MergeGate policy check" not in contexts:
     raise SystemExit(f"branch protection contexts missing MergeGate checks: {contexts}")
+PY
+
+export SHIKI_FAKE_GH_PAYLOAD="$TMP_ROOT/protect-payload-review-false.json"
+python3 - <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path.cwd() / "scripts"))
+import shiki
+
+shiki.protect_branch(
+    "example/shiki-init-protect-review-false",
+    "main",
+    ["Validate Shiki mirror"],
+    review_count=0,
+)
+PY
+python3 - "$SHIKI_FAKE_GH_PAYLOAD" <<'PY'
+import json
+import sys
+
+payload = json.load(open(sys.argv[1], encoding="utf-8"))
+reviews = payload["required_pull_request_reviews"]
+if reviews["require_code_owner_reviews"] is not False:
+    raise SystemExit("expected require_code_owner_reviews to be false when review_count is 0")
+if reviews["required_approving_review_count"] != 0:
+    raise SystemExit("expected required_approving_review_count to remain 0")
 PY
 
 echo "shiki init tests passed"

--- a/scripts/validate_shiki.py
+++ b/scripts/validate_shiki.py
@@ -12,6 +12,9 @@ from typing import Any
 from shiki_contracts import (
     CANONICAL_CCA_VERDICT_SCHEMA_PATH,
     CANONICAL_REPAIR_PACKET_SCHEMA_PATH,
+    CODEOWNERS_CRITICAL_PATHS,
+    CODEOWNERS_PATH,
+    CODEOWNERS_REQUIRED_OWNER,
     CONTRACT_SCHEMA_SCAN_PATHS,
     CONTRACT_SOURCE_OF_TRUTH_FILES,
     OBSOLETE_CCA_VERDICT_SCHEMA_PATH,
@@ -542,6 +545,33 @@ def validate_issue_forms() -> None:
                 raise ValidationError(f"{path}: label {label!r} is not declared in docs/agents/triage-labels.md")
 
 
+def validate_codeowners_governance() -> None:
+    path = ROOT / CODEOWNERS_PATH
+    if not path.exists():
+        raise ValidationError(f"{path}: CODEOWNERS file is required for critical Shiki governance paths")
+
+    coverage: dict[str, set[str]] = {}
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        if len(parts) < 2:
+            raise ValidationError(f"{path}:{line_number}: CODEOWNERS rule must include at least one owner")
+        pattern = parts[0]
+        owners = set(parts[1:])
+        coverage.setdefault(pattern, set()).update(owners)
+
+    for critical_path in CODEOWNERS_CRITICAL_PATHS:
+        owners = coverage.get(critical_path)
+        if not owners:
+            raise ValidationError(f"{path}: missing CODEOWNERS rule for {critical_path}")
+        if CODEOWNERS_REQUIRED_OWNER not in owners:
+            raise ValidationError(
+                f"{path}: {critical_path} must be owned by {CODEOWNERS_REQUIRED_OWNER}"
+            )
+
+
 def validate_prompt_contract_paths() -> None:
     suffixes = {".md", ".yml", ".yaml", ".json", ".toml"}
     for relative in CONTRACT_SCHEMA_SCAN_PATHS:
@@ -719,6 +749,7 @@ def main() -> int:
         validate_completion_check_docs()
         validate_validate_workflow_coverage()
         validate_issue_forms()
+        validate_codeowners_governance()
         validate_orchestrator_security()
 
         goal_paths = json_files(SHIKI / "goals")


### PR DESCRIPTION
## Shiki Task

- Goal: G-0012 / Issue #30
- Task: T-0032
- Issue: #44
- Runtime: codex
- Risk: critical

## Scope

Close Goal #30 P0.3.7 by adding machine-checkable CODEOWNERS governance for critical Shiki paths.

This PR:

- adds `.github/CODEOWNERS` for critical Shiki governance paths;
- makes branch protection request code-owner reviews when Shiki review enforcement is enabled;
- validates CODEOWNERS coverage and configured owner presence;
- copies CODEOWNERS through `install-target`;
- documents that CODEOWNERS governance is separate from advisory Claude review, Guardian evidence, and the CCA Review Bridge.

## Non-Goals

- Do not change runtime adapter behavior.
- Do not implement P0.2 dry-run / execute gating.
- Do not mark P0.4 state and evidence integrity items complete.
- Do not weaken CCA, Guardian, MergeGate, or required review policy.

## Locks

- path:.github/CODEOWNERS
- path:scripts/shiki.py
- path:scripts/shiki_contracts.py
- path:scripts/validate_shiki.py
- path:scripts/test_shiki_init.sh
- path:scripts/test_shiki_control_plane.sh
- path:docs/agents/decision-control.md
- path:docs/agents/bootstrap-command.md
- path:.shiki/tasks/T-0032.json
- path:.shiki/ledger/L-0106.json

## Required Skills

- tdd

## CCA Checklist Profile

- PR: Pull Request Evidence Checklist
- V: Verification Checklist
- CCA: Completion Judgment Checklist
- MG: MergeGate Checklist

## Acceptance Checks

- `.github/CODEOWNERS` exists.
- Critical Shiki governance paths require configured owner review.
- Branch protection enables code-owner reviews when Shiki config requires review.
- Validator fails if CODEOWNERS is missing or does not cover critical paths.
- Tests prove branch protection payload uses `require_code_owner_reviews: true` when review enforcement is enabled.
- Tests prove branch protection payload leaves `require_code_owner_reviews: false` when review count is 0.
- Docs explain CODEOWNERS governance and its separation from CCA Review Bridge.

## TDD Evidence

- Tests added/changed: `scripts/test_shiki_init.sh`, `scripts/test_shiki_control_plane.sh`.
- Public interfaces tested: `scripts/shiki.py init`, `scripts/shiki.py protect_branch()`, `scripts/validate_shiki.py`.
- Regression coverage proves CODEOWNERS template copy, validator wiring, `require_code_owner_reviews: true` when review enforcement is enabled, and `require_code_owner_reviews: false` when review count is 0.

## Verification

- [x] `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 scripts/validate_shiki.py`
- [x] `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 -m py_compile scripts/*.py`
- [x] `for script in scripts/test_shiki_*.sh; do PYTHONPYCACHEPREFIX=/tmp/shiki-pycache bash "$script"; done`
- [x] `git diff --check`

## Dependencies

- T-0023: done; Issue #33 closed; PR #40 merged.
- T-0031: done; PR #43 merged.

## Evidence

- Branch: `shiki/t-0032-codeowners-governance`
- Commits:
  - `c29318764c7164e6eeccd1f1bbe95cbde76a1430`: implementation
  - `a9a6402f97dd7ad1bd055036544e7a8d52223bde`: PR metadata alignment
- Head: `a9a6402f97dd7ad1bd055036544e7a8d52223bde`
- Ledger: `L-0106`
- Issue: #44

## Risk

- Risk level: critical.
- Guardian approval is required before merge.
- This PR intentionally does not self-grant Guardian approval.

## Guardian Evidence

- Guardian approval label: `guardian:approved`
- Guardian approval comment: https://github.com/mizutani-140/shiki/pull/45#issuecomment-4601953480
- Approved head: `a9a6402f97dd7ad1bd055036544e7a8d52223bde`
