### PR TITLE
shiki: add bootstrap execute gate

### DIFF
--- a/.shiki/ledger/L-0108.json
+++ b/.shiki/ledger/L-0108.json
@@ -1,0 +1,22 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    "Added --execute and --i-understand as explicit execution confirmations for bootstrap/init mutation paths.",
+    "Made init, bootstrap-platform, bootstrap-github, and uninitialized start default to dry-run before dangerous filesystem, Git, GitHub repo, secret, branch protection, default-branch, commit, or push mutations.",
+    "Dry-run output lists intended filesystem, git, GitHub repo, secret, branch protection, default-branch, commit, and push mutations.",
+    "TDD evidence: scripts/test_shiki_init.sh proves default dry-run does not call fake gh or create the target, dry-run tolerates missing secret input, and explicit --execute reaches mocked mutation paths.",
+    "Regression coverage preserves existing-origin mismatch hard-fail, --adopt-existing-repo, manifest-only staging, missing-secret hard-fail in execute mode, and branch-protection hard-fail in execute mode.",
+    "Updated start tests to use explicit --execute for the existing mutation path.",
+    "Documented dry-run vs execute behavior and existing bounded flags in docs/agents/bootstrap-command.md."
+  ],
+  "goal_id": "G-0012",
+  "id": "L-0108",
+  "links": [
+    "https://github.com/mizutani-140/shiki/issues/48",
+    "https://github.com/mizutani-140/shiki/issues/30"
+  ],
+  "summary": "Implemented P0.2.1 bootstrap/init dry-run execute gate.",
+  "task_id": "T-0033",
+  "timestamp": "2026-06-02T12:30:35Z",
+  "type": "check"
+}

--- a/.shiki/ledger/L-0108.json
+++ b/.shiki/ledger/L-0108.json
@@ -6,6 +6,7 @@
     "Dry-run output lists intended filesystem, git, GitHub repo, secret, branch protection, default-branch, commit, and push mutations.",
     "TDD evidence: scripts/test_shiki_init.sh proves default dry-run does not call fake gh or create the target, dry-run tolerates missing secret input, and explicit --execute reaches mocked mutation paths.",
     "Regression coverage preserves existing-origin mismatch hard-fail, --adopt-existing-repo, manifest-only staging, missing-secret hard-fail in execute mode, and branch-protection hard-fail in execute mode.",
+    "Bounded repair evidence: GitHub origin comparison now treats https://github.com/OWNER/REPO and https://github.com/OWNER/REPO.git as the same repository while preserving mismatch hard-fail behavior.",
     "Updated start tests to use explicit --execute for the existing mutation path.",
     "Documented dry-run vs execute behavior and existing bounded flags in docs/agents/bootstrap-command.md."
   ],

--- a/.shiki/ledger/L-0108.json
+++ b/.shiki/ledger/L-0108.json
@@ -12,6 +12,7 @@
   "goal_id": "G-0012",
   "id": "L-0108",
   "links": [
+    "https://github.com/mizutani-140/shiki/pull/49",
     "https://github.com/mizutani-140/shiki/issues/48",
     "https://github.com/mizutani-140/shiki/issues/30"
   ],

--- a/.shiki/tasks/T-0033.json
+++ b/.shiki/tasks/T-0033.json
@@ -1,0 +1,46 @@
+{
+  "acceptance_checks": [
+    "Default bootstrap/init path does not create repo, rewrite remote, commit, push, set secret, set default branch, or configure branch protection without explicit execute confirmation.",
+    "Explicit execute mode performs the intended operations or reaches the expected mocked calls in tests.",
+    "Dry-run output lists intended filesystem, git, GitHub repo, secret, branch protection, default-branch, commit, and push mutations.",
+    "Existing-origin mismatch remains hard-fail unless --adopt-existing-repo is passed.",
+    "Manifest-only staging remains intact.",
+    "Missing required secret remains hard-fail when secret setup is actually executed.",
+    "Branch protection configuration failure remains hard-fail when protection is actually executed.",
+    "Docs explain dry-run vs execute, --adopt-existing-repo, --no-set-secret, --no-protect, --commit, and --push.",
+    "Goal #30 P0.2.1 can be checked after merge."
+  ],
+  "assigned_runtime": "codex",
+  "dependencies": [
+    "T-0022",
+    "T-0032"
+  ],
+  "expected_branch": "shiki/t-0033-bootstrap-execute-gate",
+  "expected_pr": null,
+  "github_issue": 48,
+  "goal_id": "G-0012",
+  "id": "T-0033",
+  "ledger_evidence": [
+    "L-0108"
+  ],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/test_shiki_init.sh",
+    "path:scripts/test_shiki_start.sh",
+    "path:docs/agents/bootstrap-command.md",
+    "path:.shiki/tasks/T-0033.json",
+    "path:.shiki/ledger/L-0108.json"
+  ],
+  "non_goals": [
+    "Do not weaken existing P0.2.2 through P0.2.7 safety fixes.",
+    "Do not weaken P0.3 governance, CCA, MergeGate, Guardian, branch protection, or CODEOWNERS.",
+    "Do not broaden into P0.4 state, ID, lock, or evidence integrity work."
+  ],
+  "required_skills": [
+    "tdd"
+  ],
+  "risk_level": "critical",
+  "scope": "Close Goal #30 P0.2.1 by making dangerous bootstrap/init operations dry-run by default unless --execute or --i-understand is passed.",
+  "status": "review",
+  "title": "Add bootstrap/init dry-run execute gate"
+}

--- a/.shiki/tasks/T-0033.json
+++ b/.shiki/tasks/T-0033.json
@@ -16,7 +16,7 @@
     "T-0032"
   ],
   "expected_branch": "shiki/t-0033-bootstrap-execute-gate",
-  "expected_pr": null,
+  "expected_pr": 49,
   "github_issue": 48,
   "goal_id": "G-0012",
   "id": "T-0033",

--- a/docs/agents/bootstrap-command.md
+++ b/docs/agents/bootstrap-command.md
@@ -34,7 +34,18 @@ terminal entrypoints can still use `shiki start` when their own auth is ready.
 shiki start /path/to/target-repo --repo OWNER/REPO --private
 ```
 
-This is the standard user-facing Shiki entrypoint. It will:
+This is the standard user-facing Shiki entrypoint. By default it is a dry-run
+for uninitialized targets: it prints the intended bootstrap/init mutations and
+does not create a GitHub repo, mutate `origin`, commit, push, set secrets,
+change the default branch, or configure branch protection.
+
+To execute bootstrap/init mutations, pass `--execute`:
+
+```bash
+CLAUDE_CODE_OAUTH_TOKEN=... shiki start /path/to/target-repo --repo OWNER/REPO --private --execute
+```
+
+In execute mode, the command will:
 
 - install Shiki template files;
 - initialize Git if needed;
@@ -51,6 +62,7 @@ This is the standard user-facing Shiki entrypoint. It will:
 
 `shiki init` is still available as a lower-level command, but `/shiki` should
 prefer `shiki start` unless the user explicitly asks for advanced control.
+`shiki init` uses the same default dry-run and `--execute` gate.
 
 `shiki start` may run interactively. When values are missing, it asks one
 question at a time for the GitHub repo slug, project name, Goal, outcome,
@@ -63,7 +75,7 @@ Do not use `install-target` for normal setup. Shiki is GitHub-first.
 
 ### Claude Code Action Secret
 
-`shiki start`, `shiki init`, and `shiki bootstrap-platform` automatically set
+In execute mode, `shiki start`, `shiki init`, and `shiki bootstrap-platform` set
 the GitHub secret `CLAUDE_CODE_OAUTH_TOKEN` from the environment variable
 `CLAUDE_CODE_OAUTH_TOKEN`. Claude Code login by itself does not expose a GitHub
 Actions token to child processes.
@@ -90,7 +102,15 @@ Shiki must never read local Claude OAuth credential files or print token values.
 CLAUDE_CODE_OAUTH_TOKEN=... shiki bootstrap-platform --repo OWNER/shiki --private
 ```
 
-The command is idempotent. It will:
+The command is idempotent. By default it is a dry-run and prints the intended
+platform bootstrap mutations without applying them. To execute, pass
+`--execute`:
+
+```bash
+CLAUDE_CODE_OAUTH_TOKEN=... shiki bootstrap-platform --repo OWNER/shiki --private --execute
+```
+
+In execute mode, it will:
 
 - validate `.shiki/`;
 - initialize Git if needed;
@@ -104,8 +124,31 @@ The command is idempotent. It will:
 After defaults are saved, rerun:
 
 ```bash
-shiki bootstrap-platform
+shiki bootstrap-platform --execute
 ```
+
+## Dry-Run And Execute Controls
+
+`shiki start`, `shiki init`, `shiki bootstrap-platform`, and the deprecated
+`shiki bootstrap-github` alias default to dry-run. Dry-run output lists intended
+filesystem, Git, GitHub repository, secret, branch protection, default-branch,
+commit, and push mutations.
+
+Use `--execute` to apply those mutations. `--i-understand` is accepted as an
+equivalent explicit execution confirmation.
+
+The existing bounded flags still shape execute mode:
+
+- `--adopt-existing-repo` is required before Shiki rewrites an existing
+  mismatched `origin`.
+- `--no-set-secret` skips `CLAUDE_CODE_OAUTH_TOKEN` setup.
+- `--no-protect` skips branch protection configuration.
+- `--no-commit` skips manifest commit creation.
+- `--no-push` skips pushing and default-branch mutation.
+
+When execute mode is used, missing required secret input remains a hard failure
+unless `--no-set-secret` is passed, and branch protection failure remains a hard
+failure unless `--no-protect` is passed.
 
 ## Local-Only Template Copy
 

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -152,11 +152,30 @@ def ensure_git_repo(path: Path, branch: str) -> None:
         run(["git", "checkout", "-B", branch], cwd=path)
 
 
+def existing_origin_url(path: Path) -> str | None:
+    result = run(["git", "remote", "get-url", "origin"], cwd=path, check=False)
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def check_remote_adoption(repo: str, path: Path, *, adopt_existing_repo: bool = False) -> None:
+    if not path.exists() or not is_git_repo(path):
+        return
+    remote_url = f"https://github.com/{repo}.git"
+    current = existing_origin_url(path)
+    if current and current != remote_url and not adopt_existing_repo:
+        raise ShikiError(
+            "origin already points to "
+            f"{current}; refusing to rewrite it to {remote_url}. "
+            "Pass --adopt-existing-repo to explicitly adopt this repository."
+        )
+
+
 def ensure_remote(repo: str, path: Path, *, adopt_existing_repo: bool = False) -> None:
     remote_url = f"https://github.com/{repo}.git"
-    existing = run(["git", "remote", "get-url", "origin"], cwd=path, check=False)
-    if existing.returncode == 0:
-        current = existing.stdout.strip()
+    current = existing_origin_url(path)
+    if current:
         if current != remote_url:
             if not adopt_existing_repo:
                 raise ShikiError(
@@ -171,6 +190,73 @@ def ensure_remote(repo: str, path: Path, *, adopt_existing_repo: bool = False) -
         return
     run(["git", "remote", "add", "origin", remote_url], cwd=path)
     info(f"added origin {remote_url}")
+
+
+def execution_confirmed(args: argparse.Namespace) -> bool:
+    return bool(getattr(args, "execute", False) or getattr(args, "i_understand", False))
+
+
+def bootstrap_dry_run_lines(
+    *,
+    command: str,
+    target: Path,
+    repo: str,
+    branch: str,
+    visibility: str,
+    commit: bool,
+    push: bool,
+    set_secret_enabled: bool,
+    protect: bool,
+    required_checks: list[str],
+    platform: bool = False,
+) -> list[str]:
+    target_label = "platform repository" if platform else str(target)
+    lines = [
+        "dry-run: no bootstrap/init mutations were executed",
+        f"dry-run: rerun with --execute to apply these operations for {command}",
+        f"filesystem: create target directory {target_label}",
+    ]
+    if platform:
+        lines.append("filesystem: validate local Shiki platform files")
+    else:
+        lines.extend(
+            [
+                f"filesystem: install Shiki template files into {target_label}",
+                f"filesystem: write .shiki/repo.json for {repo}",
+                "filesystem: ensure .shiki state directories",
+            ]
+        )
+    lines.extend(
+        [
+            f"git: initialize repository on {branch}",
+            f"git: configure origin https://github.com/{repo}.git",
+            f"github-repo: create or reuse {repo} as {visibility}",
+        ]
+    )
+    if commit:
+        lines.append("commit: create manifest commit")
+    else:
+        lines.append("commit: skipped by --no-commit")
+    if push:
+        lines.append(f"push: push {branch} to origin")
+        lines.append(f"default-branch: set {branch}")
+    else:
+        lines.append("push: skipped by --no-push")
+        lines.append("default-branch: skipped because push is disabled")
+    if set_secret_enabled:
+        lines.append("secret: set CLAUDE_CODE_OAUTH_TOKEN")
+    else:
+        lines.append("secret: skipped by --no-set-secret")
+    if protect:
+        lines.append(f"branch-protection: configure required checks {', '.join(required_checks)}")
+    else:
+        lines.append("branch-protection: skipped by --no-protect")
+    return lines
+
+
+def print_bootstrap_dry_run(lines: list[str]) -> None:
+    for line in lines:
+        info(line)
 
 
 def require_github_repo_slug(repo: str) -> None:
@@ -1150,6 +1236,8 @@ def initialize_target_from_start(args: argparse.Namespace, target: Path, repo: s
         protect=args.protect,
         required_check=args.required_check,
         adopt_existing_repo=args.adopt_existing_repo,
+        execute=args.execute,
+        i_understand=args.i_understand,
     )
     cmd_init(init_args)
 
@@ -1163,12 +1251,18 @@ def create_issues_for_dispatchable_tasks(target: Path, task_ids: list[str]) -> l
 
 def cmd_start(args: argparse.Namespace) -> int:
     target = target_path(start_target_value(args))
-    target.mkdir(parents=True, exist_ok=True)
     answers = load_start_answers(args)
 
-    already_initialized = (target / ".shiki" / "repo.json").exists() and is_git_repo(target) and github_origin(target)
+    already_initialized = (
+        target.exists()
+        and (target / ".shiki" / "repo.json").exists()
+        and is_git_repo(target)
+        and github_origin(target)
+    )
     if not already_initialized:
         initialize_target_from_start(args, target, answers["repo"])
+        if not execution_confirmed(args):
+            return 0
     else:
         require_github_first_target(target)
         ensure_control_dirs(target)
@@ -2144,6 +2238,25 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
     branch = args.branch or config.get("default_branch") or "main"
     visibility = "private" if args.private else "public"
 
+    if not execution_confirmed(args):
+        check_remote_adoption(repo, ROOT, adopt_existing_repo=args.adopt_existing_repo)
+        print_bootstrap_dry_run(
+            bootstrap_dry_run_lines(
+                command="bootstrap-platform",
+                target=ROOT,
+                repo=repo,
+                branch=branch,
+                visibility=visibility,
+                commit=args.commit,
+                push=args.push,
+                set_secret_enabled=args.set_secret,
+                protect=args.protect,
+                required_checks=args.required_check,
+                platform=True,
+            )
+        )
+        return 0
+
     validate_local_shiki()
     run(["gh", "auth", "status"])
     ensure_git_repo(ROOT, branch)
@@ -2206,7 +2319,6 @@ def cmd_init(args: argparse.Namespace) -> int:
     require_tool("gh")
 
     target = Path(args.target).expanduser().resolve()
-    target.mkdir(parents=True, exist_ok=True)
 
     if not args.repo:
         raise ShikiError("shiki init requires --repo OWNER/NAME because Shiki is GitHub-first")
@@ -2216,6 +2328,25 @@ def cmd_init(args: argparse.Namespace) -> int:
     branch = args.branch
     visibility = "private" if args.private else "public"
 
+    if not execution_confirmed(args):
+        check_remote_adoption(repo, target, adopt_existing_repo=args.adopt_existing_repo)
+        print_bootstrap_dry_run(
+            bootstrap_dry_run_lines(
+                command="init",
+                target=target,
+                repo=repo,
+                branch=branch,
+                visibility=visibility,
+                commit=args.commit,
+                push=args.push,
+                set_secret_enabled=args.set_secret,
+                protect=args.protect,
+                required_checks=args.required_check,
+            )
+        )
+        return 0
+
+    target.mkdir(parents=True, exist_ok=True)
     run(["gh", "auth", "status"])
     ensure_git_repo(target, branch)
     ensure_github_repo(repo, visibility)
@@ -2588,6 +2719,8 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
     init.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
     init.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin to the requested GitHub repo")
+    init.add_argument("--execute", action="store_true", help="Execute bootstrap/init mutations; default is dry-run")
+    init.add_argument("--i-understand", action="store_true", help="Alias for --execute")
     init.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
     init.set_defaults(func=cmd_init)
 
@@ -2608,6 +2741,8 @@ def build_parser() -> argparse.ArgumentParser:
     github.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
     github.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
     github.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin to the requested GitHub repo")
+    github.add_argument("--execute", action="store_true", help="Execute bootstrap mutations; default is dry-run")
+    github.add_argument("--i-understand", action="store_true", help="Alias for --execute")
     github.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
     github.set_defaults(func=cmd_bootstrap_github)
 
@@ -2623,6 +2758,8 @@ def build_parser() -> argparse.ArgumentParser:
     deprecated.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
     deprecated.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
     deprecated.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin to the requested GitHub repo")
+    deprecated.add_argument("--execute", action="store_true", help="Execute bootstrap mutations; default is dry-run")
+    deprecated.add_argument("--i-understand", action="store_true", help="Alias for --execute")
     deprecated.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
     deprecated.set_defaults(func=cmd_bootstrap_github)
 
@@ -2681,6 +2818,8 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("--secret-env", default="CLAUDE_CODE_OAUTH_TOKEN")
     start.add_argument("--protect", action=argparse.BooleanOptionalAction, default=True)
     start.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin during init")
+    start.add_argument("--execute", action="store_true", help="Execute bootstrap/init mutations; default is dry-run for uninitialized targets")
+    start.add_argument("--i-understand", action="store_true", help="Alias for --execute")
     start.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
     start.add_argument("--create-issues", action=argparse.BooleanOptionalAction, default=True)
     start.add_argument("--create-handoffs", action=argparse.BooleanOptionalAction, default=True)

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -159,12 +159,25 @@ def existing_origin_url(path: Path) -> str | None:
     return result.stdout.strip()
 
 
+def canonical_github_remote_url(url: str) -> str:
+    value = url.strip().removesuffix("/")
+    if value.endswith(".git"):
+        value = value[:-4]
+    if value.startswith("git@github.com:"):
+        value = "https://github.com/" + value.removeprefix("git@github.com:")
+    return value
+
+
 def check_remote_adoption(repo: str, path: Path, *, adopt_existing_repo: bool = False) -> None:
     if not path.exists() or not is_git_repo(path):
         return
     remote_url = f"https://github.com/{repo}.git"
     current = existing_origin_url(path)
-    if current and current != remote_url and not adopt_existing_repo:
+    if (
+        current
+        and canonical_github_remote_url(current) != canonical_github_remote_url(remote_url)
+        and not adopt_existing_repo
+    ):
         raise ShikiError(
             "origin already points to "
             f"{current}; refusing to rewrite it to {remote_url}. "
@@ -176,7 +189,7 @@ def ensure_remote(repo: str, path: Path, *, adopt_existing_repo: bool = False) -
     remote_url = f"https://github.com/{repo}.git"
     current = existing_origin_url(path)
     if current:
-        if current != remote_url:
+        if canonical_github_remote_url(current) != canonical_github_remote_url(remote_url):
             if not adopt_existing_repo:
                 raise ShikiError(
                     "origin already points to "

--- a/scripts/test_shiki_init.sh
+++ b/scripts/test_shiki_init.sh
@@ -136,6 +136,14 @@ expect_fail python3 scripts/shiki.py init "$ORIGIN_MISMATCH" \
 grep "origin already points" /tmp/shiki-expected-fail.out >/dev/null
 test "$(git -C "$ORIGIN_MISMATCH" remote get-url origin)" = "https://github.com/example/wrong-repo.git"
 
+ORIGIN_WITHOUT_DOT_GIT="$TMP_ROOT/origin-without-dot-git"
+mkdir -p "$ORIGIN_WITHOUT_DOT_GIT"
+git -C "$ORIGIN_WITHOUT_DOT_GIT" init -b main >/tmp/shiki-init-origin-url-git.out
+git -C "$ORIGIN_WITHOUT_DOT_GIT" remote add origin https://github.com/example/shiki-init-test
+python3 scripts/shiki.py init "$ORIGIN_WITHOUT_DOT_GIT" \
+  --repo example/shiki-init-test >/tmp/shiki-init-origin-without-dot-git.out
+grep "dry-run: no bootstrap/init mutations were executed" /tmp/shiki-init-origin-without-dot-git.out >/dev/null
+
 ADOPTED="$TMP_ROOT/adopted"
 mkdir -p "$ADOPTED"
 git -C "$ADOPTED" init -b main >/tmp/shiki-init-adopt-git.out

--- a/scripts/test_shiki_init.sh
+++ b/scripts/test_shiki_init.sh
@@ -80,6 +80,49 @@ test -z "$(find "$TMP_ROOT/local-only/.shiki/ledger" -type f -name '*.json' -pri
 
 expect_fail python3 scripts/shiki.py preflight "$TMP_ROOT/local-only" --require-github
 
+DRY_RUN="$TMP_ROOT/dry-run"
+: >"$SHIKI_FAKE_GH_LOG"
+python3 scripts/shiki.py init "$DRY_RUN" \
+  --repo example/shiki-init-dry-run >/tmp/shiki-init-dry-run.out
+grep "dry-run: no bootstrap/init mutations were executed" /tmp/shiki-init-dry-run.out >/dev/null
+grep "filesystem: create target directory" /tmp/shiki-init-dry-run.out >/dev/null
+grep "git: initialize repository" /tmp/shiki-init-dry-run.out >/dev/null
+grep "github-repo: create or reuse example/shiki-init-dry-run" /tmp/shiki-init-dry-run.out >/dev/null
+grep "secret: set CLAUDE_CODE_OAUTH_TOKEN" /tmp/shiki-init-dry-run.out >/dev/null
+grep "branch-protection: configure required checks" /tmp/shiki-init-dry-run.out >/dev/null
+grep "default-branch: set main" /tmp/shiki-init-dry-run.out >/dev/null
+grep "commit: create manifest commit" /tmp/shiki-init-dry-run.out >/dev/null
+grep "push: push main to origin" /tmp/shiki-init-dry-run.out >/dev/null
+test ! -e "$DRY_RUN"
+test -z "$(cat "$SHIKI_FAKE_GH_LOG")"
+
+DRY_RUN_NO_SECRET="$TMP_ROOT/dry-run-no-secret"
+unset CLAUDE_CODE_OAUTH_TOKEN || true
+python3 scripts/shiki.py init "$DRY_RUN_NO_SECRET" \
+  --repo example/shiki-init-dry-run-no-secret >/tmp/shiki-init-dry-run-no-secret.out
+grep "dry-run: no bootstrap/init mutations were executed" /tmp/shiki-init-dry-run-no-secret.out >/dev/null
+
+: >"$SHIKI_FAKE_GH_LOG"
+python3 scripts/shiki.py bootstrap-platform \
+  --repo mizutani-140/shiki >/tmp/shiki-bootstrap-platform-dry-run.out
+grep "dry-run: no bootstrap/init mutations were executed" /tmp/shiki-bootstrap-platform-dry-run.out >/dev/null
+grep "filesystem: validate local Shiki platform files" /tmp/shiki-bootstrap-platform-dry-run.out >/dev/null
+grep "github-repo: create or reuse mizutani-140/shiki" /tmp/shiki-bootstrap-platform-dry-run.out >/dev/null
+test -z "$(cat "$SHIKI_FAKE_GH_LOG")"
+
+I_UNDERSTAND="$TMP_ROOT/i-understand"
+: >"$SHIKI_FAKE_GH_LOG"
+python3 scripts/shiki.py init "$I_UNDERSTAND" \
+  --repo example/shiki-init-understand \
+  --i-understand \
+  --no-commit \
+  --no-push \
+  --no-set-secret \
+  --no-protect >/tmp/shiki-init-understand.out
+test -d "$I_UNDERSTAND/.git"
+grep "auth status" "$SHIKI_FAKE_GH_LOG" >/dev/null
+grep "repo view example/shiki-init-understand --json name" "$SHIKI_FAKE_GH_LOG" >/dev/null
+
 ORIGIN_MISMATCH="$TMP_ROOT/origin-mismatch"
 mkdir -p "$ORIGIN_MISMATCH"
 git -C "$ORIGIN_MISMATCH" init -b main >/tmp/shiki-init-origin-git.out
@@ -99,6 +142,7 @@ git -C "$ADOPTED" init -b main >/tmp/shiki-init-adopt-git.out
 git -C "$ADOPTED" remote add origin https://github.com/example/wrong-repo.git
 python3 scripts/shiki.py init "$ADOPTED" \
   --repo example/shiki-init-test \
+  --execute \
   --adopt-existing-repo \
   --no-commit \
   --no-push \
@@ -111,6 +155,7 @@ mkdir -p "$STAGING"
 printf 'do not stage me\n' >"$STAGING/unrelated.txt"
 python3 scripts/shiki.py init "$STAGING" \
   --repo example/shiki-init-staging \
+  --execute \
   --no-push \
   --no-set-secret \
   --no-protect >/tmp/shiki-init-staging.out
@@ -122,6 +167,7 @@ mkdir -p "$MISSING_SECRET"
 unset CLAUDE_CODE_OAUTH_TOKEN || true
 expect_fail python3 scripts/shiki.py init "$MISSING_SECRET" \
   --repo example/shiki-init-secret \
+  --execute \
   --no-commit \
   --no-push \
   --no-protect
@@ -132,6 +178,7 @@ mkdir -p "$PROTECT_FAIL"
 export CLAUDE_CODE_OAUTH_TOKEN="fake-test-token"
 expect_fail python3 scripts/shiki.py init "$PROTECT_FAIL" \
   --repo example/shiki-init-protect \
+  --execute \
   --no-commit \
   --no-push
 grep "could not configure branch protection" /tmp/shiki-expected-fail.out >/dev/null
@@ -162,6 +209,7 @@ mkdir -p "$PROTECT_PASS"
 export SHIKI_FAKE_GH_PAYLOAD="$TMP_ROOT/protect-payload.json"
 python3 scripts/shiki.py init "$PROTECT_PASS" \
   --repo example/shiki-init-protect-pass \
+  --execute \
   --no-commit \
   --no-push >/tmp/shiki-init-protect-pass.out
 python3 - "$SHIKI_FAKE_GH_PAYLOAD" <<'PY'

--- a/scripts/test_shiki_start.sh
+++ b/scripts/test_shiki_start.sh
@@ -94,6 +94,7 @@ JSON
 python3 scripts/shiki.py start \
   "$TARGET" \
   --answers-file "$TMP_ROOT/answers.json" \
+  --execute \
   --no-push \
   --no-protect \
   >/tmp/shiki-start.json


### PR DESCRIPTION
## Shiki Task

- Goal: G-0012 / Issue #30
- Task: T-0033
- Issue: #48
- Runtime: codex
- Risk: critical

## Scope

- Add explicit `--execute` and `--i-understand` confirmation gates for dangerous bootstrap/init mutation paths.
- Make `init`, `bootstrap-platform`, deprecated `bootstrap-github`, and uninitialized `start` default to dry-run.
- Classify intended filesystem, Git, GitHub repository, secret, branch protection, default-branch, commit, and push mutations in dry-run output.
- Preserve existing safety flags and behavior for `--adopt-existing-repo`, `--no-set-secret`, `--no-protect`, `--commit` / `--no-commit`, and `--push` / `--no-push`.
- Preserve prior P0.2.2 through P0.2.7 hard-fail behavior for existing origin mismatch, required secret execution, manifest-only staging, and branch protection failures.

## Non-Goals

- Do not weaken P0.3 governance, CCA, MergeGate, Guardian, branch protection, or CODEOWNERS behavior.
- Do not broaden into P0.4 state, ID, lock, or evidence integrity work.
- Do not admin-merge or bypass Guardian review for this critical-risk change.

## Locks

- `path:scripts/shiki.py`
- `path:scripts/test_shiki_init.sh`
- `path:scripts/test_shiki_start.sh`
- `path:docs/agents/bootstrap-command.md`
- `path:.shiki/tasks/T-0033.json`
- `path:.shiki/ledger/L-0108.json`

## Required Skills

- shiki
- tdd

## Acceptance Checks

- [x] Default bootstrap/init path does not create repo, rewrite remote, commit, push, set secret, set default branch, or configure branch protection without explicit execute confirmation.
- [x] Explicit execute mode performs the intended operations or reaches the expected mocked calls in tests.
- [x] Dry-run output lists intended filesystem, git, GitHub repo, secret, branch protection, default-branch, commit, and push mutations.
- [x] Existing-origin mismatch remains hard-fail unless `--adopt-existing-repo` is passed.
- [x] Manifest-only staging remains intact.
- [x] Missing required secret remains hard-fail when secret setup is actually executed.
- [x] Branch protection configuration failure remains hard-fail when protection is actually executed.
- [x] Docs explain dry-run vs execute, `--adopt-existing-repo`, `--no-set-secret`, `--no-protect`, `--commit`, and `--push`.
- [ ] Goal #30 P0.2.1 can be checked after merge.

## Evidence

- Branch: `shiki/t-0033-bootstrap-execute-gate`
- Head: `9791e4487fdce1cfdb0796aa077f47b8b4aee6c1`
- Checks:
  - `python3 scripts/validate_shiki.py`: passed
  - `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 -m py_compile scripts/*.py`: passed
  - `for script in scripts/test_shiki_*.sh; do PYTHONPYCACHEPREFIX=/tmp/shiki-pycache bash "$script"; done`: passed
  - `git diff --check`: passed
- CCA verdict: pending
- Review: Guardian approval required for `risk: critical`; not self-granted
- Ledger: `L-0108`

## MergeGate

- [x] Dependencies are complete or not required.
- [x] Locks are registered and non-conflicting.
- [ ] Required checks passed.
- [ ] CCA verdict is `complete`.
- [ ] Required review is complete.
- [x] Required skills were used or explicitly waived.
- [x] Ledger evidence is complete.
- [ ] High-risk or critical changes have Guardian approval.
