### PR TITLE
shiki: make state ids and ledger writes collision-resistant

### DIFF
--- a/.shiki/ledger/L-0110.json
+++ b/.shiki/ledger/L-0110.json
@@ -7,6 +7,7 @@
     "Updated validate_shiki.py from contiguous ID checks to legacy/new ID format validation, filename/id matching, and duplicate rejection.",
     "Updated MergeGate task/goal ID extraction to accept the collision-resistant ID format.",
     "Regression coverage records diagnose/TDD evidence for ID uniqueness, legacy gap tolerance, malformed ID rejection, filename mismatch rejection, duplicate rejection, ledger collision retry, concurrent ledger append simulation, atomic create no-overwrite behavior, and atomic replace behavior.",
+    "improve-codebase-architecture was applied to keep the state ID and ledger atomicity helper centralized in scripts/shiki_state.py instead of spreading ad hoc allocation logic across Shiki command handlers.",
     "Documentation explains legacy ID compatibility, new generated state ID format, append-only ledger writes, and that gapless IDs are not an audit safety property.",
     "Non-goals P0.4.4 through P0.4.8 remain open."
   ],

--- a/.shiki/ledger/L-0110.json
+++ b/.shiki/ledger/L-0110.json
@@ -1,0 +1,23 @@
+{
+  "actor": "codex-front",
+  "evidence": [
+    "Added scripts/shiki_state.py with new_control_id(), atomic_create_json(), atomic_replace_json(), and append_ledger_entry().",
+    "Replaced Shiki CLI max-plus-one allocation path with collision-resistant generated IDs for new state records.",
+    "Updated append_ledger() to use append-only no-overwrite ledger creation with collision retry.",
+    "Updated validate_shiki.py from contiguous ID checks to legacy/new ID format validation, filename/id matching, and duplicate rejection.",
+    "Updated MergeGate task/goal ID extraction to accept the collision-resistant ID format.",
+    "Regression coverage records diagnose/TDD evidence for ID uniqueness, legacy gap tolerance, malformed ID rejection, filename mismatch rejection, duplicate rejection, ledger collision retry, concurrent ledger append simulation, atomic create no-overwrite behavior, and atomic replace behavior.",
+    "Documentation explains legacy ID compatibility, new generated state ID format, append-only ledger writes, and that gapless IDs are not an audit safety property.",
+    "Non-goals P0.4.4 through P0.4.8 remain open."
+  ],
+  "goal_id": "G-0012",
+  "id": "L-0110",
+  "links": [
+    "https://github.com/mizutani-140/shiki/issues/51",
+    "https://github.com/mizutani-140/shiki/issues/30"
+  ],
+  "summary": "Implemented T-0034 state ID and ledger atomicity changes.",
+  "task_id": "T-0034",
+  "timestamp": "2026-06-03T03:00:00Z",
+  "type": "check"
+}

--- a/.shiki/ledger/L-0110.json
+++ b/.shiki/ledger/L-0110.json
@@ -13,6 +13,7 @@
   "goal_id": "G-0012",
   "id": "L-0110",
   "links": [
+    "https://github.com/mizutani-140/shiki/pull/52",
     "https://github.com/mizutani-140/shiki/issues/51",
     "https://github.com/mizutani-140/shiki/issues/30"
   ],

--- a/.shiki/tasks/T-0034.json
+++ b/.shiki/tasks/T-0034.json
@@ -14,7 +14,7 @@
     "T-0033"
   ],
   "expected_branch": "shiki/t-0034-state-id-ledger-atomicity",
-  "expected_pr": null,
+  "expected_pr": 52,
   "github_issue": 51,
   "goal_id": "G-0012",
   "id": "T-0034",

--- a/.shiki/tasks/T-0034.json
+++ b/.shiki/tasks/T-0034.json
@@ -1,0 +1,52 @@
+{
+  "acceptance_checks": [
+    "Legacy sequential IDs remain valid for historical G/T/L/R records.",
+    "New generated Shiki state IDs use collision-resistant timestamp plus random suffix format instead of max-plus-one allocation.",
+    "New ledger writes are append-only, use no-overwrite creation, and retry on ID collision.",
+    "Atomic JSON helpers protect new state creation and mutable state replacement from partial writes where practical.",
+    "Validator rejects malformed IDs, filename/JSON id mismatches, and duplicate IDs without requiring gapless IDs.",
+    "Regression tests cover ID uniqueness, legacy gap tolerance, append-only ledger collision retry, concurrent append simulation, and atomic create/replace behavior.",
+    "Docs explain legacy ID compatibility, new generated ID format, append-only ledger writes, and why gapless IDs are not a safety property.",
+    "Goal #30 P0.4.1, P0.4.2, and P0.4.3 can be checked after merge and mirror reconciliation."
+  ],
+  "assigned_runtime": "codex",
+  "dependencies": [
+    "T-0033"
+  ],
+  "expected_branch": "shiki/t-0034-state-id-ledger-atomicity",
+  "expected_pr": null,
+  "github_issue": 51,
+  "goal_id": "G-0012",
+  "id": "T-0034",
+  "ledger_evidence": [
+    "L-0110"
+  ],
+  "locks": [
+    "path:scripts/shiki.py",
+    "path:scripts/shiki_state.py",
+    "path:scripts/validate_shiki.py",
+    "path:scripts/mergegate_check.py",
+    "path:scripts/test_shiki_control_plane.sh",
+    "path:scripts/test_shiki_start.sh",
+    "path:docs/agents/decision-control.md",
+    "path:docs/agents/completion-check-agent.md",
+    "path:.shiki/tasks/T-0034.json",
+    "path:.shiki/ledger/L-0110.json"
+  ],
+  "non_goals": [
+    "Do not implement P0.4.4 glob, prefix, or semantic lock conflict detection.",
+    "Do not implement P0.4.5 shared dispatch and MergeGate lock engine.",
+    "Do not implement P0.4.6 through P0.4.8 untrusted PR mutation, live GitHub state, or forged evidence protections.",
+    "Do not change CCA Review Bridge, Guardian approval, branch protection, CODEOWNERS, or unrelated MergeGate policy behavior.",
+    "Do not rewrite historical .shiki IDs."
+  ],
+  "required_skills": [
+    "diagnose",
+    "tdd",
+    "improve-codebase-architecture"
+  ],
+  "risk_level": "critical",
+  "scope": "Close Goal #30 P0.4.1 through P0.4.3 by replacing max-plus-one Shiki state allocation with collision-resistant generated IDs, making ledger appends no-overwrite, and adding atomic JSON state helpers.",
+  "status": "review",
+  "title": "Make Shiki state IDs and ledger writes collision-resistant"
+}

--- a/docs/agents/completion-check-agent.md
+++ b/docs/agents/completion-check-agent.md
@@ -48,6 +48,13 @@ CCA should read all available durable inputs:
 
 If a load-bearing input is missing, use `insufficient_evidence` or `blocked`, not `complete`.
 
+Shiki accepts both historical sequential IDs such as `G-0012`, `T-0033`, and
+`L-0109` and new collision-resistant IDs such as
+`L-20260603T121530123456Z-a1b2c3d4`. CCA must not treat contiguous or gapless
+IDs as evidence quality. For ledger evidence, CCA should prefer durable
+append-only entries whose filenames match their JSON `id`, whose IDs are unique,
+and whose content links the relevant issue, PR, checks, reviews, or artifacts.
+
 ## Verdicts
 
 | Verdict | Meaning | MergeGate impact |

--- a/docs/agents/decision-control.md
+++ b/docs/agents/decision-control.md
@@ -66,6 +66,35 @@ lock:     .shiki/locks/<task-id>.json
 ledger:   .shiki/ledger/<goal-id>/<task-id>.jsonl
 ```
 
+### State ID and Ledger Write Policy
+
+Historical Shiki state records may use legacy sequential IDs such as `G-0012`,
+`T-0033`, and `L-0109`. Validators must continue to accept those records so
+older evidence remains durable.
+
+New Shiki-generated state records use collision-resistant, filename-safe IDs:
+
+```text
+<PREFIX>-YYYYMMDDTHHMMSSffffffZ-<8 hex>
+```
+
+Examples:
+
+```text
+G-20260603T121530123456Z-a1b2c3d4
+T-20260603T121530123456Z-9f8e7d6c
+L-20260603T121530123456Z-feedface
+```
+
+Contiguous or gapless IDs are not a safety property. Audit integrity comes from
+durable evidence, matching filenames and JSON IDs, duplicate-ID rejection, and
+append-only ledger writes.
+
+Ledger writes are append-only. New ledger entries must be created with
+no-overwrite semantics and retry on ID collision. Existing ledger files must not
+be replaced during append. Mutable Shiki state records should be written through
+atomic replace helpers where practical.
+
 ### Required worktree record
 
 ```json

--- a/scripts/mergegate_check.py
+++ b/scripts/mergegate_check.py
@@ -15,8 +15,9 @@ from shiki_contracts import DEFAULT_REQUIRED_CHECKS
 from shiki_schema import SchemaValidationError, validate_instance
 
 
-TASK_ID = re.compile(r"\bT-[0-9]{4,}\b")
-GOAL_ID = re.compile(r"\bG-[0-9]{4,}\b")
+ID_SUFFIX = r"(?:[0-9]{4,}|[0-9]{8}T[0-9]{12}Z-[0-9a-f]{8})"
+TASK_ID = re.compile(rf"\bT-{ID_SUFFIX}\b")
+GOAL_ID = re.compile(rf"\bG-{ID_SUFFIX}\b")
 SELF_CHECKS = {"MergeGate policy check"}
 VERDICT_CHECKS = {"CCA verdict"}
 PLACEHOLDER_CHECKS = {"shiki-required-checks"}

--- a/scripts/shiki.py
+++ b/scripts/shiki.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Iterable
 
 from shiki_contracts import DEFAULT_REQUIRED_CHECKS, TARGET_STATE_DIRECTORIES
+from shiki_state import append_ledger_entry, atomic_replace_json, new_control_id
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -54,6 +55,7 @@ TEMPLATE_PATHS = [
     "scripts/enforce_cca_verdict.py",
     "scripts/mergegate_check.py",
     "scripts/shiki.py",
+    "scripts/shiki_state.py",
     "scripts/test_shiki_init.sh",
     "scripts/test_shiki_control_plane.sh",
     "scripts/test_shiki_run_orchestrator.sh",
@@ -543,8 +545,7 @@ def read_json(path: Path) -> dict[str, Any]:
 
 
 def write_json(path: Path, data: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    atomic_replace_json(path, data)
 
 
 def print_json(data: dict[str, Any]) -> None:
@@ -649,8 +650,27 @@ def scan_ids(target: Path, prefix: str) -> list[int]:
 
 
 def next_control_id(target: Path, prefix: str) -> str:
-    number = max(scan_ids(target, prefix), default=0) + 1
-    return f"{prefix}-{number:04d}"
+    directories = {
+        "G": ["goals", "dag"],
+        "T": ["tasks"],
+        "L": ["ledger"],
+        "P": ["plans"],
+        "RUN": ["runs"],
+        "EXEC": ["runner"],
+        "SMOKE": ["smoke"],
+        "START": ["starts"],
+        "INBOX": ["inbox"],
+        "RP": ["repairs"],
+        "R": ["reports"],
+    }.get(prefix, [])
+    base = target / ".shiki"
+    for _ in range(10):
+        candidate = new_control_id(prefix)
+        if not directories:
+            return candidate
+        if not any((base / directory / f"{candidate}.json").exists() for directory in directories):
+            return candidate
+    raise ShikiError(f"could not allocate a unique {prefix} id after 10 attempts")
 
 
 def load_task(target: Path, task_id: str) -> dict[str, Any]:
@@ -773,20 +793,23 @@ def append_ledger(
     task_id: str | None = None,
     links: list[str] | None = None,
 ) -> str:
-    ledger_id = next_control_id(target, "L")
-    payload: dict[str, Any] = {
-        "id": ledger_id,
-        "timestamp": utc_now(),
-        "goal_id": goal_id,
-        "task_id": task_id,
-        "type": ledger_type,
-        "actor": "shiki-cli",
-        "summary": summary,
-        "evidence": evidence,
-        "links": links or [],
-    }
-    write_json(shiki_path(target, "ledger", f"{ledger_id}.json"), payload)
-    return ledger_id
+    try:
+        return append_ledger_entry(
+            target,
+            lambda ledger_id: {
+                "id": ledger_id,
+                "timestamp": utc_now(),
+                "goal_id": goal_id,
+                "task_id": task_id,
+                "type": ledger_type,
+                "actor": "shiki-cli",
+                "summary": summary,
+                "evidence": evidence,
+                "links": links or [],
+            },
+        )
+    except FileExistsError as error:
+        raise ShikiError(str(error)) from error
 
 
 def register_goal_from_plan(target: Path, plan: dict[str, Any], *, github_issue: int | None = None) -> tuple[str, str]:

--- a/scripts/shiki_state.py
+++ b/scripts/shiki_state.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Atomic state helpers for Shiki control-plane JSON records."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import tempfile
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def new_control_id(prefix: str) -> str:
+    """Return a sortable, filename-safe, collision-resistant Shiki state ID."""
+    if not prefix or not all(part.isalnum() and part.isupper() for part in prefix.split("-")):
+        raise ValueError(f"invalid Shiki ID prefix: {prefix!r}")
+    now = datetime.now(timezone.utc)
+    timestamp = now.strftime("%Y%m%dT%H%M%S") + f"{now.microsecond:06d}Z"
+    return f"{prefix}-{timestamp}-{secrets.token_hex(4)}"
+
+
+def json_text(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def _write_temp_json(path: Path, payload: dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json_text(payload))
+            handle.flush()
+            os.fsync(handle.fileno())
+        return temp_path
+    except BaseException:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def atomic_create_json(path: Path, payload: dict[str, Any]) -> None:
+    """Create a JSON file only if it does not exist. Never overwrite."""
+    temp_path = _write_temp_json(path, payload)
+    try:
+        os.link(temp_path, path)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def atomic_replace_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON through a temp file and atomically replace the destination."""
+    temp_path = _write_temp_json(path, payload)
+    try:
+        os.replace(temp_path, path)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def append_ledger_entry(
+    target: Path,
+    payload_factory: Callable[[str], dict[str, Any]],
+    *,
+    retries: int = 10,
+) -> str:
+    """Append a ledger entry using no-overwrite creation and collision retry."""
+    ledger_dir = target / ".shiki" / "ledger"
+    for _ in range(retries):
+        ledger_id = new_control_id("L")
+        payload = payload_factory(ledger_id)
+        payload["id"] = ledger_id
+        try:
+            atomic_create_json(ledger_dir / f"{ledger_id}.json", payload)
+            return ledger_id
+        except FileExistsError:
+            continue
+    raise FileExistsError(f"could not allocate a unique ledger id after {retries} attempts")

--- a/scripts/test_shiki_control_plane.sh
+++ b/scripts/test_shiki_control_plane.sh
@@ -26,6 +26,7 @@ cd "$ROOT"
 
 python3 scripts/validate_shiki.py
 python3 -m py_compile scripts/shiki.py
+python3 -m py_compile scripts/shiki_state.py
 python3 -m py_compile scripts/shiki_schema.py
 python3 -m py_compile scripts/shiki_contracts.py
 python3 scripts/shiki.py --help | grep -E "goal|issue|dispatch|repair" >/dev/null
@@ -84,6 +85,97 @@ grep "can_approve_pull_request_reviews" .github/workflows/shiki-cca-completion.y
 grep "This is not advisory Claude review" .github/workflows/shiki-cca-completion.yml >/dev/null
 grep "reviewDecision,statusCheckRollup" .github/workflows/shiki-cca-completion.yml >/dev/null
 
+python3 - "$ROOT" <<'PY'
+import json
+import pathlib
+import re
+import sys
+import tempfile
+import threading
+
+root = pathlib.Path(sys.argv[1])
+sys.path.insert(0, str(root / "scripts"))
+import shiki_state
+
+ids = [shiki_state.new_control_id("L") for _ in range(200)]
+assert len(ids) == len(set(ids))
+assert all(re.match(r"^L-\d{8}T\d{12}Z-[0-9a-f]{8}$", value) for value in ids)
+assert not any(re.match(r"^L-\d{4,}$", value) for value in ids)
+
+with tempfile.TemporaryDirectory() as tmp:
+    target = pathlib.Path(tmp)
+    ledger_dir = target / ".shiki" / "ledger"
+    ledger_dir.mkdir(parents=True)
+    (ledger_dir / "L-9999.json").write_text('{"id":"L-9999"}\n')
+
+    create_path = target / ".shiki" / "state" / "record.json"
+    shiki_state.atomic_create_json(create_path, {"id": "record", "value": 1})
+    before = create_path.read_text()
+    try:
+        shiki_state.atomic_create_json(create_path, {"id": "record", "value": 2})
+    except FileExistsError:
+        pass
+    else:
+        raise AssertionError("atomic_create_json must fail on existing files")
+    assert create_path.read_text() == before
+
+    replace_path = target / ".shiki" / "state" / "replace.json"
+    shiki_state.atomic_replace_json(replace_path, {"id": "replace", "value": 1})
+    shiki_state.atomic_replace_json(replace_path, {"id": "replace", "value": 2})
+    assert json.loads(replace_path.read_text())["value"] == 2
+    assert not list(replace_path.parent.glob("*.tmp"))
+
+    values = iter(["L-20260603T121530123456Z-deadbeef", "L-20260603T121530123457Z-feedface"])
+    original = shiki_state.new_control_id
+    shiki_state.new_control_id = lambda prefix: next(values)
+    try:
+        (ledger_dir / "L-20260603T121530123456Z-deadbeef.json").write_text('{"id":"existing","value":1}\n')
+        ledger_id = shiki_state.append_ledger_entry(
+            target,
+            lambda candidate: {
+                "id": candidate,
+                "timestamp": "2026-06-03T00:00:00+00:00",
+                "goal_id": "G-0001",
+                "type": "check",
+                "actor": "test",
+                "summary": "collision retry",
+                "evidence": ["retry"],
+            },
+            retries=2,
+        )
+    finally:
+        shiki_state.new_control_id = original
+    assert ledger_id == "L-20260603T121530123457Z-feedface"
+    assert json.loads((ledger_dir / "L-20260603T121530123456Z-deadbeef.json").read_text())["id"] == "existing"
+
+    created: list[str] = []
+    lock = threading.Lock()
+
+    def append_one() -> None:
+        new_id = shiki_state.append_ledger_entry(
+            target,
+            lambda candidate: {
+                "id": candidate,
+                "timestamp": "2026-06-03T00:00:00+00:00",
+                "goal_id": "G-0001",
+                "type": "check",
+                "actor": "test",
+                "summary": "concurrent append",
+                "evidence": ["thread"],
+            },
+        )
+        with lock:
+            created.append(new_id)
+
+    threads = [threading.Thread(target=append_one) for _ in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert len(created) == len(set(created)) == 20
+    assert not (ledger_dir / "L-10000.json").exists()
+PY
+
 expect_fail env \
   CCA_VERDICT_FILE=/tmp/shiki-cca-invalid-complete.json \
   STRUCTURED_OUTPUT='{"verdict":"complete"}' \
@@ -105,6 +197,7 @@ grep "CCA verdict complete" /tmp/shiki-cca-valid-complete.out >/dev/null
 mkdir -p "$TARGET"
 python3 scripts/shiki.py install-target "$TARGET" --local-only >/tmp/shiki-control-install.out
 test -f "$TARGET/.github/CODEOWNERS"
+test -f "$TARGET/scripts/shiki_state.py"
 test -f "$TARGET/skills/engineering/shiki/SKILL.md"
 test -f "$TARGET/skills/engineering/grill-with-docs/SKILL.md"
 
@@ -146,6 +239,108 @@ text = path.read_text()
 path.write_text(text.replace("Current conversation", "GitHub Issues, Pull Requests, Checks, Reviews, comments, and merge evidence"))
 PY
 
+python3 - "$TARGET" <<'PY'
+import json
+import pathlib
+import sys
+
+target = pathlib.Path(sys.argv[1])
+ledger = target / ".shiki" / "ledger"
+goal = target / ".shiki" / "goals"
+goal.mkdir(parents=True, exist_ok=True)
+(goal / "G-9999.json").write_text(json.dumps({
+    "acceptance_evidence": ["validator fixture"],
+    "completion_conditions": ["validator fixture"],
+    "id": "G-9999",
+    "non_goals": [],
+    "outcome": "validator fixture",
+    "required_skills": ["tdd"],
+    "risk_level": "low",
+    "status": "historical",
+    "title": "Validator fixture",
+}, indent=2, sort_keys=True) + "\n")
+
+def write_ledger(path_name: str, entry_id: str) -> None:
+    payload = {
+        "actor": "validator-test",
+        "evidence": ["validator id fixture"],
+        "goal_id": "G-9999",
+        "id": entry_id,
+        "links": [],
+        "summary": "validator id fixture",
+        "timestamp": "2026-06-03T00:00:00+00:00",
+        "type": "check",
+    }
+    (ledger / path_name).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+write_ledger("L-9999.json", "L-9999")
+write_ledger("L-20260603T121530123456Z-a1b2c3d4.json", "L-20260603T121530123456Z-a1b2c3d4")
+PY
+python3 "$TARGET/scripts/validate_shiki.py"
+
+python3 - "$TARGET" <<'PY'
+import json
+import pathlib
+import sys
+target = pathlib.Path(sys.argv[1])
+payload = {
+    "actor": "validator-test",
+    "evidence": ["filename mismatch fixture"],
+    "goal_id": "G-9999",
+    "id": "L-20260603T121530123456Z-a1b2c3d4",
+    "links": [],
+    "summary": "filename mismatch fixture",
+    "timestamp": "2026-06-03T00:00:00+00:00",
+    "type": "check",
+}
+(target / ".shiki" / "ledger" / "L-20260603T121530123457Z-a1b2c3d4.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+expect_fail python3 "$TARGET/scripts/validate_shiki.py"
+grep "duplicate id" /tmp/shiki-expected-fail.out >/dev/null
+rm "$TARGET/.shiki/ledger/L-20260603T121530123457Z-a1b2c3d4.json"
+
+python3 - "$TARGET" <<'PY'
+import json
+import pathlib
+import sys
+target = pathlib.Path(sys.argv[1])
+payload = {
+    "actor": "validator-test",
+    "evidence": ["filename mismatch fixture"],
+    "goal_id": "G-9999",
+    "id": "L-20260603T121530123458Z-a1b2c3d4",
+    "links": [],
+    "summary": "filename mismatch fixture",
+    "timestamp": "2026-06-03T00:00:00+00:00",
+    "type": "check",
+}
+(target / ".shiki" / "ledger" / "L-20260603T121530123459Z-a1b2c3d4.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+expect_fail python3 "$TARGET/scripts/validate_shiki.py"
+grep "file name must match id" /tmp/shiki-expected-fail.out >/dev/null
+rm "$TARGET/.shiki/ledger/L-20260603T121530123459Z-a1b2c3d4.json"
+
+python3 - "$TARGET" <<'PY'
+import json
+import pathlib
+import sys
+target = pathlib.Path(sys.argv[1])
+payload = {
+    "actor": "validator-test",
+    "evidence": ["malformed id fixture"],
+    "goal_id": "G-9999",
+    "id": "L-not-valid",
+    "links": [],
+    "summary": "malformed id fixture",
+    "timestamp": "2026-06-03T00:00:00+00:00",
+    "type": "check",
+}
+(target / ".shiki" / "ledger" / "L-not-valid.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+expect_fail python3 "$TARGET/scripts/validate_shiki.py"
+grep "id must match L-0001 or L-YYYYMMDDTHHMMSSffffffZ-<8 hex>" /tmp/shiki-expected-fail.out >/dev/null
+rm "$TARGET/.shiki/ledger/L-not-valid.json"
+
 cd "$TARGET"
 git init -b main >/tmp/shiki-control-git-init.out
 # Hermetic git identity so `git commit` works in CI where no global git user is configured.
@@ -164,6 +359,11 @@ python3 "$ROOT/scripts/shiki.py" goal create \
   >/tmp/shiki-goal-create.json
 
 GOAL_ID="$(json_get /tmp/shiki-goal-create.json goal_id)"
+case "$GOAL_ID" in
+  G-[0-9][0-9][0-9][0-9]) echo "goal id unexpectedly used legacy max-plus-one format: $GOAL_ID" >&2; exit 1 ;;
+  G-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]Z-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *) echo "unexpected goal id: $GOAL_ID" >&2; exit 1 ;;
+esac
 test -f "$TARGET/.shiki/goals/$GOAL_ID.json"
 
 python3 "$ROOT/scripts/shiki.py" issue plan \
@@ -178,6 +378,11 @@ python3 "$ROOT/scripts/shiki.py" issue plan \
   >/tmp/shiki-issue-plan.json
 
 TASK_ID="$(json_get /tmp/shiki-issue-plan.json task_id)"
+case "$TASK_ID" in
+  T-[0-9][0-9][0-9][0-9]) echo "task id unexpectedly used legacy max-plus-one format: $TASK_ID" >&2; exit 1 ;;
+  T-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]Z-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *) echo "unexpected task id: $TASK_ID" >&2; exit 1 ;;
+esac
 test -f "$TARGET/.shiki/tasks/$TASK_ID.json"
 test -f "$TARGET/.shiki/dag/$GOAL_ID.json"
 
@@ -209,8 +414,10 @@ task_path = target / ".shiki" / "tasks" / f"{task_id}.json"
 task = json.loads(task_path.read_text())
 task["expected_pr"] = 123
 task["status"] = "review"
-ledger_numbers = [int(path.stem.split("-")[1]) for path in (target / ".shiki" / "ledger").glob("L-*.json")]
-ledger_id = f"L-{max(ledger_numbers, default=0) + 1:04d}"
+ledger_id = "L-9999"
+while (target / ".shiki" / "ledger" / f"{ledger_id}.json").exists():
+    number = int(ledger_id.split("-")[1]) - 1
+    ledger_id = f"L-{number:04d}"
 task["ledger_evidence"].append(ledger_id)
 task_path.write_text(json.dumps(task, indent=2, sort_keys=True) + "\n")
 

--- a/scripts/test_shiki_start.sh
+++ b/scripts/test_shiki_start.sh
@@ -100,9 +100,9 @@ python3 scripts/shiki.py start \
   >/tmp/shiki-start.json
 
 test -f "$TARGET/.shiki/repo.json"
-test -f "$TARGET/.shiki/plans/P-0001.json"
-test -f "$TARGET/.shiki/runs/RUN-0001.json"
-test -f "$TARGET/.shiki/starts/START-0001.json"
+test -n "$(find "$TARGET/.shiki/plans" -type f -name 'P-*.json' -print -quit)"
+test -n "$(find "$TARGET/.shiki/runs" -type f -name 'RUN-*.json' -print -quit)"
+test -n "$(find "$TARGET/.shiki/starts" -type f -name 'START-*.json' -print -quit)"
 test -n "$(find "$TARGET/.shiki/tasks" -type f -name 'T-*.json' -print -quit)"
 grep "repo create" "$SHIKI_FAKE_GH_LOG" >/dev/null
 grep "issue create" "$SHIKI_FAKE_GH_LOG" >/dev/null
@@ -112,7 +112,11 @@ grep '"configured": true' /tmp/shiki-start.json >/dev/null
 START_ID="$(json_get /tmp/shiki-start.json start_id)"
 GOAL_ID="$(json_get /tmp/shiki-start.json goal_id)"
 SKILLS_DIR="$(json_get /tmp/shiki-start.json skills_dir)"
-test "$START_ID" = "START-0001"
+case "$START_ID" in
+  START-[0-9][0-9][0-9][0-9] | START-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]T[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]Z-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]) ;;
+  *) echo "unexpected start id: $START_ID" >&2; exit 1 ;;
+esac
+test -f "$TARGET/.shiki/starts/$START_ID.json"
 test -n "$SKILLS_DIR"
 test -f "$TARGET/.shiki/goals/$GOAL_ID.json"
 

--- a/scripts/validate_shiki.py
+++ b/scripts/validate_shiki.py
@@ -27,15 +27,23 @@ from shiki_contracts import (
 ROOT = Path(__file__).resolve().parents[1]
 SHIKI = ROOT / ".shiki"
 
-TASK_ID = re.compile(r"^T-[0-9]{4,}$")
-GOAL_ID = re.compile(r"^G-[0-9]{4,}$")
-LEDGER_ID = re.compile(r"^L-[0-9]{4,}$")
-PLAN_ID = re.compile(r"^P-[0-9]{4,}$")
-RUN_ID = re.compile(r"^RUN-[0-9]{4,}$")
-INBOX_ID = re.compile(r"^INBOX-[0-9]{4,}$")
-EXEC_ID = re.compile(r"^EXEC-[0-9]{4,}$")
-SMOKE_ID = re.compile(r"^SMOKE-[0-9]{4,}$")
-START_ID = re.compile(r"^START-[0-9]{4,}$")
+ID_SUFFIX = r"(?:[0-9]{4,}|[0-9]{8}T[0-9]{12}Z-[0-9a-f]{8})"
+
+
+def control_id_pattern(prefix: str) -> re.Pattern[str]:
+    return re.compile(rf"^{re.escape(prefix)}-{ID_SUFFIX}$")
+
+
+TASK_ID = control_id_pattern("T")
+GOAL_ID = control_id_pattern("G")
+LEDGER_ID = control_id_pattern("L")
+PLAN_ID = control_id_pattern("P")
+RUN_ID = control_id_pattern("RUN")
+INBOX_ID = control_id_pattern("INBOX")
+EXEC_ID = control_id_pattern("EXEC")
+SMOKE_ID = control_id_pattern("SMOKE")
+START_ID = control_id_pattern("START")
+REPORT_ID = control_id_pattern("R")
 
 TASK_REQUIRED = {
     "id",
@@ -140,6 +148,15 @@ def load_json(path: Path) -> Any:
         raise ValidationError(f"{path}: invalid JSON: {error}") from error
 
 
+def id_format_description(prefix: str) -> str:
+    return f"{prefix}-0001 or {prefix}-YYYYMMDDTHHMMSSffffffZ-<8 hex>"
+
+
+def require_control_id(path: Path, value: str, pattern: re.Pattern[str], prefix: str, field: str = "id") -> None:
+    if not pattern.match(value):
+        raise ValidationError(f"{path}: {field} must match {id_format_description(prefix)}")
+
+
 def require_keys(path: Path, data: dict[str, Any], keys: set[str]) -> None:
     missing = sorted(keys - set(data))
     if missing:
@@ -187,8 +204,7 @@ def validate_goal(path: Path, data: dict[str, Any]) -> str:
     require_keys(path, data, GOAL_REQUIRED)
 
     goal_id = require_string(path, data, "id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G")
 
     require_string(path, data, "title")
     require_string(path, data, "outcome")
@@ -213,12 +229,10 @@ def validate_task(path: Path, data: dict[str, Any]) -> tuple[str, list[str]]:
     require_keys(path, data, TASK_REQUIRED)
 
     task_id = require_string(path, data, "id")
-    if not TASK_ID.match(task_id):
-        raise ValidationError(f"{path}: id must match T-0001 style")
+    require_control_id(path, task_id, TASK_ID, "T")
 
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
 
     require_string(path, data, "title")
     require_string(path, data, "scope")
@@ -244,7 +258,7 @@ def validate_task(path: Path, data: dict[str, Any]) -> tuple[str, list[str]]:
 
     for dependency in dependencies:
         if not isinstance(dependency, str) or not TASK_ID.match(dependency):
-            raise ValidationError(f"{path}: dependencies must contain T-0001 style ids")
+            raise ValidationError(f"{path}: dependencies must contain {id_format_description('T')} ids")
 
     validate_skill_names(path, require_list(path, data, "required_skills"), key="required_skills")
 
@@ -254,15 +268,14 @@ def validate_task(path: Path, data: dict[str, Any]) -> tuple[str, list[str]]:
 def validate_dag(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
     require_keys(path, data, DAG_REQUIRED)
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
 
     nodes = require_list(path, data, "nodes", non_empty=True)
     edges = require_list(path, data, "edges")
 
     for node in nodes:
         if not isinstance(node, str) or not TASK_ID.match(node):
-            raise ValidationError(f"{path}: nodes must contain T-0001 style ids")
+            raise ValidationError(f"{path}: nodes must contain {id_format_description('T')} ids")
         if known_tasks and node not in known_tasks:
             raise ValidationError(f"{path}: node {node} has no matching task file")
 
@@ -305,19 +318,17 @@ def validate_ledger(path: Path, data: dict[str, Any], known_tasks: set[str], kno
     require_keys(path, data, LEDGER_REQUIRED)
 
     ledger_id = require_string(path, data, "id")
-    if not LEDGER_ID.match(ledger_id):
-        raise ValidationError(f"{path}: id must match L-0001 style")
+    require_control_id(path, ledger_id, LEDGER_ID, "L")
 
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
     if known_goals and goal_id not in known_goals:
         raise ValidationError(f"{path}: goal_id {goal_id} has no matching goal file")
 
     task_id = data.get("task_id")
     if task_id is not None:
         if not isinstance(task_id, str) or not TASK_ID.match(task_id):
-            raise ValidationError(f"{path}: task_id must match T-0001 style or null")
+            raise ValidationError(f"{path}: task_id must match {id_format_description('T')} or null")
         if known_tasks and task_id not in known_tasks:
             raise ValidationError(f"{path}: task_id {task_id} has no matching task file")
 
@@ -347,14 +358,12 @@ def validate_worktree(path: Path, data: dict[str, Any], known_tasks: set[str]) -
     require_keys(path, data, required)
 
     task_id = require_string(path, data, "task_id")
-    if not TASK_ID.match(task_id):
-        raise ValidationError(f"{path}: task_id must match T-0001 style")
+    require_control_id(path, task_id, TASK_ID, "T", field="task_id")
     if known_tasks and task_id not in known_tasks:
         raise ValidationError(f"{path}: task_id {task_id} has no matching task file")
 
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
 
     require_string(path, data, "branch")
     require_string(path, data, "path")
@@ -368,8 +377,7 @@ def validate_worktree(path: Path, data: dict[str, Any], known_tasks: set[str]) -
 def validate_plan(path: Path, data: dict[str, Any]) -> None:
     require_keys(path, data, PLAN_REQUIRED)
     plan_id = require_string(path, data, "id")
-    if not PLAN_ID.match(plan_id):
-        raise ValidationError(f"{path}: id must match P-0001 style")
+    require_control_id(path, plan_id, PLAN_ID, "P")
     require_string(path, data, "title")
     require_string(path, data, "outcome")
 
@@ -393,18 +401,15 @@ def validate_plan(path: Path, data: dict[str, Any]) -> None:
 def validate_run(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
     require_keys(path, data, RUN_REQUIRED)
     run_id = require_string(path, data, "id")
-    if not RUN_ID.match(run_id):
-        raise ValidationError(f"{path}: id must match RUN-0001 style")
+    require_control_id(path, run_id, RUN_ID, "RUN")
     plan_id = require_string(path, data, "plan_id")
-    if not PLAN_ID.match(plan_id):
-        raise ValidationError(f"{path}: plan_id must match P-0001 style")
+    require_control_id(path, plan_id, PLAN_ID, "P", field="plan_id")
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
     for key in ("task_ids", "dispatchable_task_ids"):
         for task_id in require_list(path, data, key):
             if not isinstance(task_id, str) or not TASK_ID.match(task_id):
-                raise ValidationError(f"{path}: {key} must contain T-0001 style ids")
+                raise ValidationError(f"{path}: {key} must contain {id_format_description('T')} ids")
             if known_tasks and task_id not in known_tasks:
                 raise ValidationError(f"{path}: {key} references unknown task {task_id}")
     if not isinstance(data.get("blocked_task_ids"), dict):
@@ -417,16 +422,13 @@ def validate_run(path: Path, data: dict[str, Any], known_tasks: set[str]) -> Non
 def validate_runner_record(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
     require_keys(path, data, RUNNER_REQUIRED)
     exec_id = require_string(path, data, "id")
-    if not EXEC_ID.match(exec_id):
-        raise ValidationError(f"{path}: id must match EXEC-0001 style")
+    require_control_id(path, exec_id, EXEC_ID, "EXEC")
     task_id = require_string(path, data, "task_id")
-    if not TASK_ID.match(task_id):
-        raise ValidationError(f"{path}: task_id must match T-0001 style")
+    require_control_id(path, task_id, TASK_ID, "T", field="task_id")
     if known_tasks and task_id not in known_tasks:
         raise ValidationError(f"{path}: task_id {task_id} has no matching task file")
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
     require_string(path, data, "command")
     if not isinstance(data.get("returncode"), int):
         raise ValidationError(f"{path}: returncode must be an integer")
@@ -438,8 +440,7 @@ def validate_runner_record(path: Path, data: dict[str, Any], known_tasks: set[st
 def validate_smoke(path: Path, data: dict[str, Any]) -> None:
     require_keys(path, data, SMOKE_REQUIRED)
     smoke_id = require_string(path, data, "id")
-    if not SMOKE_ID.match(smoke_id):
-        raise ValidationError(f"{path}: id must match SMOKE-0001 style")
+    require_control_id(path, smoke_id, SMOKE_ID, "SMOKE")
     require_string(path, data, "repo")
     if not isinstance(data.get("dry_run"), bool):
         raise ValidationError(f"{path}: dry_run must be a boolean")
@@ -451,8 +452,7 @@ def validate_smoke(path: Path, data: dict[str, Any]) -> None:
 def validate_start(path: Path, data: dict[str, Any], known_tasks: set[str]) -> None:
     require_keys(path, data, START_REQUIRED)
     start_id = require_string(path, data, "id")
-    if not START_ID.match(start_id):
-        raise ValidationError(f"{path}: id must match START-0001 style")
+    require_control_id(path, start_id, START_ID, "START")
     require_string(path, data, "repo")
     require_string(path, data, "project_name")
     require_string(path, data, "skills_dir")
@@ -460,17 +460,14 @@ def validate_start(path: Path, data: dict[str, Any], known_tasks: set[str]) -> N
     if not questions or not all(isinstance(question, str) and question for question in questions):
         raise ValidationError(f"{path}: questions must be a non-empty list of strings")
     plan_id = require_string(path, data, "plan_id")
-    if not PLAN_ID.match(plan_id):
-        raise ValidationError(f"{path}: plan_id must match P-0001 style")
+    require_control_id(path, plan_id, PLAN_ID, "P", field="plan_id")
     goal_id = require_string(path, data, "goal_id")
-    if not GOAL_ID.match(goal_id):
-        raise ValidationError(f"{path}: goal_id must match G-0001 style")
+    require_control_id(path, goal_id, GOAL_ID, "G", field="goal_id")
     run_id = require_string(path, data, "run_id")
-    if not RUN_ID.match(run_id):
-        raise ValidationError(f"{path}: run_id must match RUN-0001 style")
+    require_control_id(path, run_id, RUN_ID, "RUN", field="run_id")
     for task_id in require_list(path, data, "dispatchable_task_ids"):
         if not isinstance(task_id, str) or not TASK_ID.match(task_id):
-            raise ValidationError(f"{path}: dispatchable_task_ids must contain T-0001 style ids")
+            raise ValidationError(f"{path}: dispatchable_task_ids must contain {id_format_description('T')} ids")
         if known_tasks and task_id not in known_tasks:
             raise ValidationError(f"{path}: dispatchable task {task_id} has no matching task file")
     require_list(path, data, "issues")
@@ -484,20 +481,25 @@ def json_files(directory: Path) -> list[Path]:
     return sorted(path for path in directory.glob("*.json") if path.is_file())
 
 
-def require_contiguous_ids(paths: list[Path], prefix: str) -> None:
-    if not paths:
-        return
-    numbers: list[int] = []
+def validate_id_collection(
+    paths: list[Path],
+    *,
+    prefix: str,
+    pattern: re.Pattern[str],
+    field: str = "id",
+) -> None:
+    seen: dict[str, Path] = {}
     for path in paths:
-        match = re.match(rf"^{re.escape(prefix)}-([0-9]{{4,}})\.json$", path.name)
-        if match:
-            numbers.append(int(match.group(1)))
-    if not numbers:
-        return
-    expected = list(range(1, max(numbers) + 1))
-    if sorted(numbers) != expected:
-        missing = sorted(set(expected) - set(numbers))
-        raise ValidationError(f"{paths[0].parent}: missing contiguous {prefix} ids: {missing}")
+        data = load_json(path)
+        if not isinstance(data, dict):
+            raise ValidationError(f"{path}: state record must be a JSON object")
+        value = require_string(path, data, field)
+        require_control_id(path, value, pattern, prefix, field=field)
+        if value in seen:
+            raise ValidationError(f"{path}: duplicate {field} {value} also appears in {seen[value]}")
+        if path.name != f"{value}.json":
+            raise ValidationError(f"{path}: file name must match {field} {value}")
+        seen[value] = path
 
 
 def allowed_labels_from_docs() -> set[str]:
@@ -758,11 +760,11 @@ def main() -> int:
         dag_paths = json_files(SHIKI / "dag")
         report_paths = json_files(SHIKI / "reports")
 
-        require_contiguous_ids(goal_paths, "G")
-        require_contiguous_ids(task_paths, "T")
-        require_contiguous_ids(ledger_paths, "L")
-        require_contiguous_ids(dag_paths, "G")
-        require_contiguous_ids(report_paths, "R")
+        validate_id_collection(goal_paths, prefix="G", pattern=GOAL_ID)
+        validate_id_collection(task_paths, prefix="T", pattern=TASK_ID)
+        validate_id_collection(ledger_paths, prefix="L", pattern=LEDGER_ID)
+        validate_id_collection(dag_paths, prefix="G", pattern=GOAL_ID, field="goal_id")
+        validate_id_collection(report_paths, prefix="R", pattern=REPORT_ID)
 
         for goal_path in goal_paths:
             data = load_json(goal_path)


### PR DESCRIPTION
## Shiki PR

Task: T-0034
Issue: #51
Goal: G-0012 / #30
Runtime: codex
Risk: critical

## Summary

This PR makes Shiki control-plane state IDs and ledger writes collision-resistant.

Implemented scope:

- Add `scripts/shiki_state.py` for timestamp-plus-random control IDs and atomic JSON writes.
- Replace max-plus-one ID allocation in `scripts/shiki.py`.
- Make ledger append no-overwrite and retry on collision.
- Keep historical sequential IDs valid for existing mirror state.
- Update validation to reject duplicate IDs and filename/JSON ID mismatches without requiring gapless numeric sequences.
- Update MergeGate metadata parsing to accept both historical and collision-resistant Task/Goal IDs.
- Add regression coverage for concurrent ledger appends, forced collisions, atomic create/replace, new generated task/goal IDs, and legacy sparse history.
- Document collision-resistant IDs and append-only ledger write policy.

## Non-Goals

- Does not implement P0.4.4 through P0.4.8.
- Does not implement P1.1 or P1.3.
- Does not change CCA Review Bridge, Guardian approval, branch protection, CODEOWNERS, or unrelated MergeGate behavior.
- Does not rewrite historical `.shiki` IDs.
- Does not close Goal #30.

## Locks

- `path:scripts/shiki.py`
- `path:scripts/shiki_state.py`
- `path:scripts/validate_shiki.py`
- `path:scripts/mergegate_check.py`
- `path:scripts/test_shiki_control_plane.sh`
- `path:scripts/test_shiki_start.sh`
- `path:docs/agents/decision-control.md`
- `path:docs/agents/completion-check-agent.md`
- `path:.shiki/tasks/T-0034.json`
- `path:.shiki/ledger/L-0110.json`

## Required Skills

- diagnose
- tdd
- improve-codebase-architecture
- shiki

## Acceptance

- [x] New Task/Goal/Ledger IDs are not allocated by scanning max numeric suffix plus one.
- [x] New generated IDs are collision-resistant.
- [x] Ledger writes are no-overwrite or otherwise atomic enough to avoid silent clobbering.
- [x] Concurrent ledger writes do not overwrite one another in regression coverage.
- [x] Existing historical IDs remain valid.
- [x] Validator no longer assumes contiguous ID sequences as correctness.
- [x] Validator rejects duplicate IDs.
- [x] Validator rejects filename/JSON ID mismatch.
- [x] Docs explain historical vs generated ID policy.
- [ ] Goal #30 P0.4.1, P0.4.2, and P0.4.3 can be checked after merge and mirror reconciliation.

## Verification

Head: `9f3d2f9069916aeecfa655b4fb83bbc83102f3b0`

Local verification passed:

- `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 scripts/validate_shiki.py`
- `PYTHONPYCACHEPREFIX=/tmp/shiki-pycache python3 -m py_compile scripts/*.py`
- `for script in scripts/test_shiki_*.sh; do PYTHONPYCACHEPREFIX=/tmp/shiki-pycache bash "$script"; done`
- `git diff --check`

## Evidence

- Task mirror: `.shiki/tasks/T-0034.json`
- Ledger evidence: `.shiki/ledger/L-0110.json`
- Issue: #51

## MergeGate

- [x] Task metadata present.
- [x] Goal metadata present.
- [x] Risk is critical.
- [x] Locks are declared.
- [x] Required skills are recorded.
- [x] Ledger evidence is present.
- [ ] CCA verdict passes.
- [ ] MergeGate metadata check passes.
- [ ] MergeGate policy check passes.
- [ ] Validate Shiki mirror passes.
- [ ] Claude review passes.
- [ ] Guardian approval recorded.

This PR must not be merged until Guardian approval is granted and all required checks pass.
