### PR TITLE
shiki: T-20260606T062652655666Z-2b63a06f P0.3.2 — derive required checks from config

### DIFF
--- a/.shiki/ledger/L-20260606T062652655831Z-cda0ae28.json
+++ b/.shiki/ledger/L-20260606T062652655831Z-cda0ae28.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/tasks/T-20260606T062652655666Z-2b63a06f.json"
+  ],
+  "goal_id": "G-0012",
+  "id": "L-20260606T062652655831Z-cda0ae28",
+  "links": [],
+  "summary": "Task registered: P0.3.2 \u2014 Derive required checks from config (remove hard-coded CLI defaults)",
+  "task_id": "T-20260606T062652655666Z-2b63a06f",
+  "timestamp": "2026-06-06T06:26:52+00:00",
+  "type": "task-registered"
+}

--- a/.shiki/ledger/L-20260606T062704546588Z-e02c1e58.json
+++ b/.shiki/ledger/L-20260606T062704546588Z-e02c1e58.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/locks/T-20260606T062652655666Z-2b63a06f.json"
+  ],
+  "goal_id": "G-0012",
+  "id": "L-20260606T062704546588Z-e02c1e58",
+  "links": [],
+  "summary": "Locks acquired for T-20260606T062652655666Z-2b63a06f",
+  "task_id": "T-20260606T062652655666Z-2b63a06f",
+  "timestamp": "2026-06-06T06:27:04+00:00",
+  "type": "lock"
+}

--- a/.shiki/ledger/L-20260606T062704611731Z-a1be2db3.json
+++ b/.shiki/ledger/L-20260606T062704611731Z-a1be2db3.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/worktrees/T-20260606T062652655666Z-2b63a06f.json"
+  ],
+  "goal_id": "G-0012",
+  "id": "L-20260606T062704611731Z-a1be2db3",
+  "links": [],
+  "summary": "Worktree allocated for T-20260606T062652655666Z-2b63a06f",
+  "task_id": "T-20260606T062652655666Z-2b63a06f",
+  "timestamp": "2026-06-06T06:27:04+00:00",
+  "type": "handoff"
+}

--- a/.shiki/ledger/L-20260606T063303695736Z-bd5d7d29.json
+++ b/.shiki/ledger/L-20260606T063303695736Z-bd5d7d29.json
@@ -4,12 +4,14 @@
     "python3 scripts/validate_shiki.py passed",
     "python3 -m unittest discover -s tests: 50 tests OK (8 new in test_required_checks_derivation.py)",
     "all 28 scripts/test_shiki_*.sh passed",
-    "skills: diagnose tdd improve-codebase-architecture"
+    "skills: diagnose tdd improve-codebase-architecture",
+    "https://github.com/mizutani-140/shiki/pull/113"
   ],
   "goal_id": "G-0012",
   "id": "L-20260606T063303695736Z-bd5d7d29",
   "links": [
-    "#112"
+    "#112",
+    "https://github.com/mizutani-140/shiki/pull/113"
   ],
   "summary": "P0.3.2 implemented and verified. Required checks now derive from .shiki/config.yaml via shiki_config.configured_required_checks; DEFAULT_REQUIRED_CHECKS kept only as documented fallback; shiki_cli --required-check defaults set to None; shiki_bootstrap resolves config-derived checks. Skills applied: diagnose, tdd, improve-codebase-architecture.",
   "task_id": "T-20260606T062652655666Z-2b63a06f",

--- a/.shiki/ledger/L-20260606T063303695736Z-bd5d7d29.json
+++ b/.shiki/ledger/L-20260606T063303695736Z-bd5d7d29.json
@@ -1,0 +1,18 @@
+{
+  "actor": "codex",
+  "evidence": [
+    "python3 scripts/validate_shiki.py passed",
+    "python3 -m unittest discover -s tests: 50 tests OK (8 new in test_required_checks_derivation.py)",
+    "all 28 scripts/test_shiki_*.sh passed",
+    "skills: diagnose tdd improve-codebase-architecture"
+  ],
+  "goal_id": "G-0012",
+  "id": "L-20260606T063303695736Z-bd5d7d29",
+  "links": [
+    "#112"
+  ],
+  "summary": "P0.3.2 implemented and verified. Required checks now derive from .shiki/config.yaml via shiki_config.configured_required_checks; DEFAULT_REQUIRED_CHECKS kept only as documented fallback; shiki_cli --required-check defaults set to None; shiki_bootstrap resolves config-derived checks. Skills applied: diagnose, tdd, improve-codebase-architecture.",
+  "task_id": "T-20260606T062652655666Z-2b63a06f",
+  "timestamp": "2026-06-06T06:33:03Z",
+  "type": "check"
+}

--- a/.shiki/locks/T-20260606T062652655666Z-2b63a06f.json
+++ b/.shiki/locks/T-20260606T062652655666Z-2b63a06f.json
@@ -1,0 +1,20 @@
+{
+  "created_at": "2026-06-06T06:27:04+00:00",
+  "goal_id": "G-0012",
+  "locks": [
+    "path:scripts/shiki_config.py",
+    "path:scripts/shiki_cli.py",
+    "path:scripts/shiki_bootstrap.py",
+    "path:tests/test_required_checks_derivation.py",
+    "path:.shiki/tasks/T-20260606T062652655666Z-2b63a06f.json",
+    "path:.shiki/locks/T-20260606T062652655666Z-2b63a06f.json",
+    "path:.shiki/worktrees/T-20260606T062652655666Z-2b63a06f.json",
+    "path:.shiki/ledger/L-20260606T062652655831Z-cda0ae28.json",
+    "path:.shiki/ledger/L-20260606T062704546588Z-e02c1e58.json",
+    "path:.shiki/ledger/L-20260606T062704611731Z-a1be2db3.json",
+    "path:.shiki/ledger/L-20260606T063303695736Z-bd5d7d29.json"
+  ],
+  "owner": "codex",
+  "state": "active",
+  "task_id": "T-20260606T062652655666Z-2b63a06f"
+}

--- a/.shiki/tasks/T-20260606T062652655666Z-2b63a06f.json
+++ b/.shiki/tasks/T-20260606T062652655666Z-2b63a06f.json
@@ -1,0 +1,48 @@
+{
+  "acceptance_checks": [
+    "python3 scripts/validate_shiki.py passes",
+    "python3 -m unittest discover -s tests passes",
+    "config change alters branch-protection payload contexts; fallback used only when config absent"
+  ],
+  "assigned_runtime": "codex",
+  "dependencies": [],
+  "expected_branch": "shiki/G-0012/p0-3-2-required-checks",
+  "expected_pr": null,
+  "github_issue": 112,
+  "goal_id": "G-0012",
+  "id": "T-20260606T062652655666Z-2b63a06f",
+  "ledger_evidence": [
+    "L-20260606T062652655831Z-cda0ae28",
+    "L-20260606T062704546588Z-e02c1e58",
+    "L-20260606T062704611731Z-a1be2db3",
+    "L-20260606T063303695736Z-bd5d7d29"
+  ],
+  "locks": [
+    "path:scripts/shiki_config.py",
+    "path:scripts/shiki_cli.py",
+    "path:scripts/shiki_bootstrap.py",
+    "path:tests/test_required_checks_derivation.py",
+    "path:.shiki/tasks/T-20260606T062652655666Z-2b63a06f.json",
+    "path:.shiki/locks/T-20260606T062652655666Z-2b63a06f.json",
+    "path:.shiki/worktrees/T-20260606T062652655666Z-2b63a06f.json",
+    "path:.shiki/ledger/L-20260606T062652655831Z-cda0ae28.json",
+    "path:.shiki/ledger/L-20260606T062704546588Z-e02c1e58.json",
+    "path:.shiki/ledger/L-20260606T062704611731Z-a1be2db3.json",
+    "path:.shiki/ledger/L-20260606T063303695736Z-bd5d7d29.json"
+  ],
+  "non_goals": [
+    "Do not change required_review policy (#106)",
+    "Do not change Guardian/CODEOWNERS",
+    "Do not rewrite MergeGate broadly",
+    "Do not change workflow job names"
+  ],
+  "required_skills": [
+    "diagnose",
+    "tdd",
+    "improve-codebase-architecture"
+  ],
+  "risk_level": "high",
+  "scope": "Derive --required-check from .shiki/config.yaml via a canonical shiki_config helper; keep DEFAULT_REQUIRED_CHECKS as documented fallback; change shiki_cli defaults to None; resolve in shiki_bootstrap handlers; add regression tests.",
+  "status": "review",
+  "title": "P0.3.2 \u2014 Derive required checks from config (remove hard-coded CLI defaults)"
+}

--- a/.shiki/tasks/T-20260606T062652655666Z-2b63a06f.json
+++ b/.shiki/tasks/T-20260606T062652655666Z-2b63a06f.json
@@ -7,7 +7,7 @@
   "assigned_runtime": "codex",
   "dependencies": [],
   "expected_branch": "shiki/G-0012/p0-3-2-required-checks",
-  "expected_pr": null,
+  "expected_pr": 113,
   "github_issue": 112,
   "goal_id": "G-0012",
   "id": "T-20260606T062652655666Z-2b63a06f",

--- a/.shiki/worktrees/T-20260606T062652655666Z-2b63a06f.json
+++ b/.shiki/worktrees/T-20260606T062652655666Z-2b63a06f.json
@@ -1,0 +1,17 @@
+{
+  "branch": "shiki/G-0012/p0-3-2-required-checks",
+  "created_at": "2026-06-06T06:27:04+00:00",
+  "created_by": "shiki-cli",
+  "goal_id": "G-0012",
+  "locks": [
+    "path:scripts/shiki_config.py",
+    "path:scripts/shiki_cli.py",
+    "path:scripts/shiki_bootstrap.py",
+    "path:tests/test_required_checks_derivation.py"
+  ],
+  "path": "/Users/kio.mizutani/shiki/.claude/worktrees/.worktrees/shiki-g-0012-p0-3-2-required-checks",
+  "pr": null,
+  "runtime": "codex",
+  "state": "registered",
+  "task_id": "T-20260606T062652655666Z-2b63a06f"
+}

--- a/scripts/shiki_bootstrap.py
+++ b/scripts/shiki_bootstrap.py
@@ -9,7 +9,8 @@ from pathlib import Path
 import sys
 from typing import Any
 
-from shiki_config import branch_protection_review_count
+from shiki_config import branch_protection_review_count, configured_required_checks
+from shiki_contracts import DEFAULT_REQUIRED_CHECKS
 from shiki_git import check_remote_adoption, commit_manifest, current_branch, ensure_git_repo, ensure_remote, github_origin, is_git_repo, push_branch
 from shiki_github import claude_secret_remediation, configure_claude_code_secret, create_github_issue_for_task, ensure_github_repo, github_secret_status, protect_branch, require_github_repo_slug, set_default_branch
 from shiki_installer import install_template
@@ -143,7 +144,7 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
                 push=args.push,
                 set_secret_enabled=args.set_secret,
                 protect=args.protect,
-                required_checks=args.required_check,
+                required_checks=args.required_check or configured_required_checks(ROOT, DEFAULT_REQUIRED_CHECKS),
                 provider_config=provider_config,
                 platform=True,
             )
@@ -170,7 +171,8 @@ def cmd_bootstrap_github(args: argparse.Namespace) -> int:
     configure_claude_code_secret(repo, enabled=args.set_secret, secret_env=args.secret_env, provider_config=provider_config)
 
     if args.protect:
-        protect_branch(repo, branch, args.required_check, review_count=branch_protection_review_count(ROOT), provider_config=provider_config)
+        required_checks = args.required_check or configured_required_checks(ROOT, DEFAULT_REQUIRED_CHECKS)
+        protect_branch(repo, branch, required_checks, review_count=branch_protection_review_count(ROOT), provider_config=provider_config)
 
     save_default_config(repo, branch)
     info("bootstrap complete")
@@ -218,7 +220,7 @@ def cmd_init(args: argparse.Namespace) -> int:
                 push=args.push,
                 set_secret_enabled=args.set_secret,
                 protect=args.protect,
-                required_checks=args.required_check,
+                required_checks=args.required_check or configured_required_checks(target, DEFAULT_REQUIRED_CHECKS),
                 provider_config=provider_config,
             )
         )
@@ -246,7 +248,8 @@ def cmd_init(args: argparse.Namespace) -> int:
     configure_claude_code_secret(repo, enabled=args.set_secret, secret_env=args.secret_env, provider_config=provider_config)
 
     if args.protect:
-        protect_branch(repo, branch, args.required_check, review_count=branch_protection_review_count(target), provider_config=provider_config)
+        required_checks = args.required_check or configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        protect_branch(repo, branch, required_checks, review_count=branch_protection_review_count(target), provider_config=provider_config)
 
     info("GitHub-first init complete")
     return 0

--- a/scripts/shiki_cli.py
+++ b/scripts/shiki_cli.py
@@ -7,7 +7,6 @@ import argparse
 import sys
 from typing import Iterable
 
-from shiki_contracts import DEFAULT_REQUIRED_CHECKS
 from shiki_bootstrap import cmd_bootstrap_github, cmd_init, cmd_preflight, cmd_start
 from shiki_doctor import cmd_doctor
 from shiki_github import cmd_github_issue, cmd_github_pr
@@ -47,7 +46,7 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin to the requested GitHub repo")
     init.add_argument("--execute", action="store_true", help="Execute bootstrap/init mutations; default is dry-run")
     init.add_argument("--i-understand", action="store_true", help="Alias for --execute")
-    init.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    init.add_argument("--required-check", action="append", default=None, help="Required status-check context; repeatable. Default derives from .shiki/config.yaml mergegate.required_checks (documented fallback when config is absent).")
     init.set_defaults(func=cmd_init)
 
     preflight = subcommands.add_parser("preflight", help="Check whether a target repo is ready for Shiki")
@@ -70,7 +69,7 @@ def build_parser() -> argparse.ArgumentParser:
     github.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin to the requested GitHub repo")
     github.add_argument("--execute", action="store_true", help="Execute bootstrap mutations; default is dry-run")
     github.add_argument("--i-understand", action="store_true", help="Alias for --execute")
-    github.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    github.add_argument("--required-check", action="append", default=None, help="Required status-check context; repeatable. Default derives from .shiki/config.yaml mergegate.required_checks (documented fallback when config is absent).")
     github.set_defaults(func=cmd_bootstrap_github)
 
     deprecated = subcommands.add_parser("bootstrap-github", help="Deprecated alias for bootstrap-platform")
@@ -88,7 +87,7 @@ def build_parser() -> argparse.ArgumentParser:
     deprecated.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin to the requested GitHub repo")
     deprecated.add_argument("--execute", action="store_true", help="Execute bootstrap mutations; default is dry-run")
     deprecated.add_argument("--i-understand", action="store_true", help="Alias for --execute")
-    deprecated.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    deprecated.add_argument("--required-check", action="append", default=None, help="Required status-check context; repeatable. Default derives from .shiki/config.yaml mergegate.required_checks (documented fallback when config is absent).")
     deprecated.set_defaults(func=cmd_bootstrap_github)
 
     target = subcommands.add_parser("install-target", help="Install Shiki template files only; GitHub-first setup uses init")
@@ -171,7 +170,7 @@ def build_parser() -> argparse.ArgumentParser:
     start.add_argument("--adopt-existing-repo", action="store_true", help="Explicitly rewrite an existing origin during init")
     start.add_argument("--execute", action="store_true", help="Execute bootstrap/init mutations; default is dry-run for uninitialized targets")
     start.add_argument("--i-understand", action="store_true", help="Alias for --execute")
-    start.add_argument("--required-check", action="append", default=list(DEFAULT_REQUIRED_CHECKS))
+    start.add_argument("--required-check", action="append", default=None, help="Required status-check context; repeatable. Default derives from .shiki/config.yaml mergegate.required_checks (documented fallback when config is absent).")
     start.add_argument("--create-issues", action=argparse.BooleanOptionalAction, default=True)
     start.add_argument("--create-handoffs", action=argparse.BooleanOptionalAction, default=True)
     start.set_defaults(func=cmd_start)

--- a/scripts/shiki_config.py
+++ b/scripts/shiki_config.py
@@ -64,3 +64,16 @@ def configured_required_review(target: Path) -> bool:
 
 def branch_protection_review_count(target: Path) -> int:
     return 1 if configured_required_review(target) else 0
+
+
+def configured_required_checks(target: Path, default: "list[str] | tuple[str, ...]") -> list[str]:
+    """Required status-check contexts derived from .shiki/config.yaml.
+
+    Canonical, config-first source for branch-protection setup. ``default`` is the
+    documented fallback (DEFAULT_REQUIRED_CHECKS), used only when the target has no
+    ``mergegate.required_checks`` entries (e.g. before config is installed).
+    """
+    mergegate = load_shiki_config(target).get("mergegate", {})
+    raw = mergegate.get("required_checks") if isinstance(mergegate, dict) else None
+    checks = [str(check) for check in raw or [] if str(check).strip()]
+    return checks or list(default)

--- a/tests/test_required_checks_derivation.py
+++ b/tests/test_required_checks_derivation.py
@@ -1,0 +1,136 @@
+"""P0.3.2 — required checks derive from .shiki/config.yaml, not hard-coded CLI defaults.
+
+`shiki_config.configured_required_checks` is the canonical config-first source used
+by bootstrap/init to configure GitHub branch protection. These tests prove:
+- a config change alters the derived checks (and the branch-protection payload contexts);
+- the hard-coded DEFAULT_REQUIRED_CHECKS is used ONLY as a documented fallback when
+  the target has no `mergegate.required_checks` (missing or empty);
+- the `shiki init`/`bootstrap-platform` CLI no longer hard-codes the defaults.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import shiki_test_support  # noqa: F401  (path bootstrap)
+
+import shiki_config
+import shiki_github
+from shiki_contracts import DEFAULT_REQUIRED_CHECKS
+
+
+def _write_config(body: str) -> Path:
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / ".shiki").mkdir(parents=True)
+    (tmp / ".shiki" / "config.yaml").write_text(body, encoding="utf-8")
+    return tmp
+
+
+CUSTOM_CONFIG = """version: 1
+mergegate:
+  required_checks:
+    - Validate Shiki mirror
+    - Custom Project Check
+    - CCA verdict
+"""
+
+EMPTY_CHECKS_CONFIG = """version: 1
+mergegate:
+  required_checks:
+"""
+
+
+class ConfiguredRequiredChecksTests(unittest.TestCase):
+    def test_config_overrides_hard_coded_default(self) -> None:
+        target = _write_config(CUSTOM_CONFIG)
+        result = shiki_config.configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        self.assertEqual(result, ["Validate Shiki mirror", "Custom Project Check", "CCA verdict"])
+        # The stale hard-coded default is NOT used when config defines checks.
+        self.assertNotEqual(result, list(DEFAULT_REQUIRED_CHECKS))
+        self.assertIn("Custom Project Check", result)
+
+    def test_missing_config_uses_documented_fallback(self) -> None:
+        target = Path(tempfile.mkdtemp())  # no .shiki/config.yaml
+        result = shiki_config.configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        self.assertEqual(result, list(DEFAULT_REQUIRED_CHECKS))
+
+    def test_empty_required_checks_uses_documented_fallback(self) -> None:
+        target = _write_config(EMPTY_CHECKS_CONFIG)
+        result = shiki_config.configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        self.assertEqual(result, list(DEFAULT_REQUIRED_CHECKS))
+
+    def test_returns_new_list_not_default_alias(self) -> None:
+        target = Path(tempfile.mkdtemp())
+        result = shiki_config.configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        result.append("mutation")
+        # Mutating the result must not corrupt the shared default tuple/list.
+        self.assertNotIn("mutation", DEFAULT_REQUIRED_CHECKS)
+
+
+class _RunRecorder:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, args, *, input_text=None, env=None, check=False, **kwargs):
+        self.calls.append({"args": args, "input_text": input_text})
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+class BranchProtectionContextsFollowConfigTests(unittest.TestCase):
+    """The branch-protection payload contexts must reflect config, not the default."""
+
+    def setUp(self) -> None:
+        self._orig_run = shiki_github.run
+        self._orig_info = shiki_github.info
+        shiki_github.info = lambda *a, **k: None
+
+    def tearDown(self) -> None:
+        shiki_github.run = self._orig_run
+        shiki_github.info = self._orig_info
+
+    def _payload_contexts(self, checks: list[str]) -> list[str]:
+        import json
+        rec = _RunRecorder()
+        shiki_github.run = rec
+        shiki_github.protect_branch("owner/name", "main", checks, review_count=1)
+        # The payload JSON is passed as --input - via input_text.
+        call = rec.calls[-1]
+        payload = json.loads(call["input_text"])
+        return payload["required_status_checks"]["contexts"]
+
+    def test_config_checks_flow_into_payload(self) -> None:
+        target = _write_config(CUSTOM_CONFIG)
+        derived = shiki_config.configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        contexts = self._payload_contexts(derived)
+        self.assertEqual(contexts, ["Validate Shiki mirror", "Custom Project Check", "CCA verdict"])
+        self.assertIn("Custom Project Check", contexts)
+
+    def test_fallback_checks_flow_into_payload_when_config_absent(self) -> None:
+        target = Path(tempfile.mkdtemp())
+        derived = shiki_config.configured_required_checks(target, DEFAULT_REQUIRED_CHECKS)
+        contexts = self._payload_contexts(derived)
+        self.assertEqual(contexts, list(DEFAULT_REQUIRED_CHECKS))
+
+
+class CliNoLongerHardCodesDefaultsTests(unittest.TestCase):
+    """`shiki init`/`bootstrap-platform` must not bake DEFAULT_REQUIRED_CHECKS into argparse."""
+
+    def test_required_check_default_is_none(self) -> None:
+        import shiki_cli
+        parser = shiki_cli.build_parser()
+        ns = parser.parse_args(["init", "/tmp/x", "--repo", "owner/name"])
+        # Omitting --required-check must yield None so the handler derives from config.
+        self.assertIsNone(ns.required_check)
+
+    def test_explicit_required_check_is_collected(self) -> None:
+        import shiki_cli
+        parser = shiki_cli.build_parser()
+        ns = parser.parse_args(["init", "/tmp/x", "--repo", "owner/name", "--required-check", "Only One"])
+        self.assertEqual(ns.required_check, ["Only One"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Shiki Task
- Goal: G-0012 (#30)
- Task: T-20260606T062652655666Z-2b63a06f (#112)
- Issue: #112
- Runtime: codex
- Risk: high

## Scope
P0.3.2 — stop hard-coding default required checks in the CLI. `shiki init/start/bootstrap-platform` now derive `--required-check` from `.shiki/config.yaml` (`mergegate.required_checks`) at execution time; `DEFAULT_REQUIRED_CHECKS` (scripts/shiki_contracts.py) is kept only as a documented fallback when config is absent/empty. (scripts/shiki.py is a thin shim post module-split; defaults lived in shiki_cli.py.)

- `scripts/shiki_config.py`: new canonical dependency-free `configured_required_checks(target, default)`.
- `scripts/shiki_cli.py`: 4 `--required-check` defaults changed from `list(DEFAULT_REQUIRED_CHECKS)` to `None` (+ help); removed now-unused import.
- `scripts/shiki_bootstrap.py`: `cmd_init`/`cmd_bootstrap_github` resolve `args.required_check or configured_required_checks(...)` (init derives after template install).
- `tests/test_required_checks_derivation.py`: regression tests.

## Non-Goals
- No change to `required_review` solo/team policy (#106).
- No change to Guardian semantics or CODEOWNERS.
- No broad MergeGate rewrite (`mergegate_check.configured_required_checks` already derives from config; left intact).
- No workflow job-name changes. No P2 reopen.

## Locks
- path:scripts/shiki_config.py, path:scripts/shiki_cli.py, path:scripts/shiki_bootstrap.py, path:tests/test_required_checks_derivation.py
- plus this task's own .shiki task/lock/worktree/ledger files (exact paths)

## Required Skills
- diagnose, tdd, improve-codebase-architecture (recorded in task ledger)

## Acceptance Checks
- python3 scripts/validate_shiki.py — PASS
- python3 -m py_compile scripts/*.py — PASS
- python3 -m unittest discover -s tests — 50 OK (8 new)
- all 28 scripts/test_shiki_*.sh — PASS (incl. test_shiki_init.sh, module boundaries)

## Evidence
- Branch: shiki/G-0012/p0-3-2-required-checks
- Ledger: L-20260606T063303695736Z-bd5d7d29 (+ task-registered/lock entries)
- CCA: pending | Review: pending

## CCA checklist profile
G, GD, CI, TDD, PR, V, CCA, MG — bounded high-risk MergeGate-config change.

## MergeGate
- [x] Locks registered and non-conflicting
- [x] Required checks pass locally
- [ ] CCA verdict complete
- [ ] Guardian approval — **REQUIRED (high risk: branch protection / required-check enforcement) — requesting @mizutani-140**

_Guardian approval recorded (label + current-head comment) for head acb1a500aae9b09e0cd58899a095164e1b01d268._
