### PR TITLE
T-20260612T045948146790Z-a27bcfa2: Establish claude-code as default implementer: registry roles, runtime adapter boundary, shiki runner claude, tests, docs, ADR 0008

### DIFF
--- a/.shiki/goals/G-20260612T045923586452Z-8f7011ec.json
+++ b/.shiki/goals/G-20260612T045923586452Z-8f7011ec.json
@@ -13,6 +13,9 @@
   "created_at": "2026-06-12T04:59:23+00:00",
   "github_issue": 119,
   "id": "G-20260612T045923586452Z-8f7011ec",
+  "ledger_evidence": [
+    "L-20260612T054443779008Z-a798112a"
+  ],
   "non_goals": [
     "No spec_freeze plan contract changes (G-C scope)",
     "No autonomous loop, auto-merge, or repair auto-dispatch (G-D scope)",
@@ -25,6 +28,6 @@
     "tdd"
   ],
   "risk_level": "medium",
-  "status": "planned",
+  "status": "complete",
   "title": "G-A: Claude Code as default implementer runtime with shiki runner claude adapter"
 }

--- a/.shiki/ledger/L-20260612T054443696606Z-7ecda253.json
+++ b/.shiki/ledger/L-20260612T054443696606Z-7ecda253.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/tasks/T-20260612T045948146790Z-a27bcfa2.json"
+  ],
+  "goal_id": "G-20260612T045923586452Z-8f7011ec",
+  "id": "L-20260612T054443696606Z-7ecda253",
+  "links": [],
+  "summary": "Task T-20260612T045948146790Z-a27bcfa2 status changed to done",
+  "task_id": "T-20260612T045948146790Z-a27bcfa2",
+  "timestamp": "2026-06-12T05:44:43+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260612T054443779008Z-a798112a.json
+++ b/.shiki/ledger/L-20260612T054443779008Z-a798112a.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/reports/R-20260612T054443778171Z-879f72d2.json"
+  ],
+  "goal_id": "G-20260612T045923586452Z-8f7011ec",
+  "id": "L-20260612T054443779008Z-a798112a",
+  "links": [],
+  "summary": "G-A complete: claude-code is the default implementer runtime; shiki runner claude dispatches via the runtime adapter boundary; ADR 0008/0009 and CONTEXT.md glossary recorded; merged as PR #120",
+  "task_id": null,
+  "timestamp": "2026-06-12T05:44:43+00:00",
+  "type": "completion"
+}

--- a/.shiki/ledger/L-20260612T054500706823Z-82551799.json
+++ b/.shiki/ledger/L-20260612T054500706823Z-82551799.json
@@ -1,0 +1,15 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    "https://github.com/mizutani-140/shiki/pull/121"
+  ],
+  "goal_id": "G-20260612T045923586452Z-8f7011ec",
+  "id": "L-20260612T054500706823Z-82551799",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/121"
+  ],
+  "summary": "GitHub PR #121 created for T-20260612T045948146790Z-a27bcfa2",
+  "task_id": "T-20260612T045948146790Z-a27bcfa2",
+  "timestamp": "2026-06-12T05:45:00+00:00",
+  "type": "handoff"
+}

--- a/.shiki/locks/T-20260612T045948146790Z-a27bcfa2.json
+++ b/.shiki/locks/T-20260612T045948146790Z-a27bcfa2.json
@@ -22,6 +22,6 @@
     "path:SYSTEM_PROMPT.md"
   ],
   "owner": "shiki-cli",
-  "state": "active",
+  "state": "released",
   "task_id": "T-20260612T045948146790Z-a27bcfa2"
 }

--- a/.shiki/reports/R-20260612T054443778171Z-879f72d2.json
+++ b/.shiki/reports/R-20260612T054443778171Z-879f72d2.json
@@ -1,0 +1,19 @@
+{
+  "blocking_reasons": [],
+  "created_at": "2026-06-12T05:44:43+00:00",
+  "evidence": [
+    ".shiki/tasks/T-20260612T045948146790Z-a27bcfa2.json"
+  ],
+  "goal_id": "G-20260612T045923586452Z-8f7011ec",
+  "id": "R-20260612T054443778171Z-879f72d2",
+  "mergegate": {
+    "checks": "pass",
+    "dependencies": "pass",
+    "ledger": "pass",
+    "locks": "pass",
+    "review": "recorded",
+    "risk": "medium"
+  },
+  "status": "complete",
+  "summary": "G-A complete: claude-code is the default implementer runtime; shiki runner claude dispatches via the runtime adapter boundary; ADR 0008/0009 and CONTEXT.md glossary recorded; merged as PR #120"
+}

--- a/.shiki/tasks/T-20260612T045948146790Z-a27bcfa2.json
+++ b/.shiki/tasks/T-20260612T045948146790Z-a27bcfa2.json
@@ -10,7 +10,7 @@
   "assigned_runtime": "claude-code",
   "dependencies": [],
   "expected_branch": "shiki/t-a27bcfa2-post-merge-reconcile",
-  "expected_pr": 120,
+  "expected_pr": 121,
   "github_issue": 119,
   "goal_id": "G-20260612T045923586452Z-8f7011ec",
   "id": "T-20260612T045948146790Z-a27bcfa2",
@@ -25,7 +25,8 @@
     "L-20260612T053540157300Z-b0df682e",
     "L-20260612T053540158176Z-1e1a7626",
     "L-20260612T054443696606Z-7ecda253",
-    "L-20260612T054443779008Z-a798112a"
+    "L-20260612T054443779008Z-a798112a",
+    "L-20260612T054500706823Z-82551799"
   ],
   "locks": [
     "path:scripts/shiki_runtime.py",

--- a/.shiki/tasks/T-20260612T045948146790Z-a27bcfa2.json
+++ b/.shiki/tasks/T-20260612T045948146790Z-a27bcfa2.json
@@ -9,7 +9,7 @@
   ],
   "assigned_runtime": "claude-code",
   "dependencies": [],
-  "expected_branch": "shiki/g-8f7011ec-claude-default-runner",
+  "expected_branch": "shiki/t-a27bcfa2-post-merge-reconcile",
   "expected_pr": 120,
   "github_issue": 119,
   "goal_id": "G-20260612T045923586452Z-8f7011ec",
@@ -23,7 +23,9 @@
     "L-20260612T053259839357Z-a2d2be2c",
     "L-20260612T053349378376Z-3d70c7ec",
     "L-20260612T053540157300Z-b0df682e",
-    "L-20260612T053540158176Z-1e1a7626"
+    "L-20260612T053540158176Z-1e1a7626",
+    "L-20260612T054443696606Z-7ecda253",
+    "L-20260612T054443779008Z-a798112a"
   ],
   "locks": [
     "path:scripts/shiki_runtime.py",
@@ -57,6 +59,6 @@
   ],
   "risk_level": "medium",
   "scope": "Grant claude-code the implementer and runner roles in scripts/shiki_runtime_registry.py and set implementer: claude-code in .shiki/config.yaml. Extract the shared runner machinery from cmd_runner_codex into a runtime adapter boundary (new module scripts/shiki_runtime_adapters.py: ExecResult, RunnerAdapter, adapter registry, auth probes) and add shiki runner claude (headless claude -p in the registered worktree, EXEC + ledger evidence, review/repair-needed transition). Default task runtime becomes claude-code. Sync installer TEMPLATE_PATHS, validator SHIKI_CLI_MODULE_FILES, module-boundary/staging/registry tests; add scripts/test_shiki_runner_claude.sh and tests/test_runner_adapters.py. Update runtime-split docs (AGENTS.md, CLAUDE.md, docs/agents/runtime-registry.md, runtime-auth-model.md, implementation-policy.md, control-commands.md, codex-handoff.md, bootstrap-command.md, .claude/commands/shiki.md, .codex/skills/shiki/SKILL.md). Commit decision records: ADR 0008, ADR 0009, CONTEXT.md glossary (Requirements Definition, Spec Freeze, Spec Amendment, Assumption Log). Guardian-approved implementation by Claude Code in this assigned task.",
-  "status": "review",
+  "status": "done",
   "title": "Establish claude-code as default implementer: registry roles, runtime adapter boundary, shiki runner claude, tests, docs, ADR 0008"
 }

--- a/.shiki/worktrees/T-20260612T045948146790Z-a27bcfa2.json
+++ b/.shiki/worktrees/T-20260612T045948146790Z-a27bcfa2.json
@@ -22,7 +22,7 @@
     "path:.codex/skills/shiki/SKILL.md"
   ],
   "path": "/Users/kio.mizutani/shiki",
-  "pr": 120,
+  "pr": 121,
   "runtime": "claude-code",
   "state": "registered",
   "task_id": "T-20260612T045948146790Z-a27bcfa2"


### PR DESCRIPTION
## Shiki
Goal: G-20260612T045923586452Z-8f7011ec
Task: T-20260612T045948146790Z-a27bcfa2
CCA checklist profile: PR, TDD, V, CCA

## Scope
Grant claude-code the implementer and runner roles in scripts/shiki_runtime_registry.py and set implementer: claude-code in .shiki/config.yaml. Extract the shared runner machinery from cmd_runner_codex into a runtime adapter boundary (new module scripts/shiki_runtime_adapters.py: ExecResult, RunnerAdapter, adapter registry, auth probes) and add shiki runner claude (headless claude -p in the registered worktree, EXEC + ledger evidence, review/repair-needed transition). Default task runtime becomes claude-code. Sync installer TEMPLATE_PATHS, validator SHIKI_CLI_MODULE_FILES, module-boundary/staging/registry tests; add scripts/test_shiki_runner_claude.sh and tests/test_runner_adapters.py. Update runtime-split docs (AGENTS.md, CLAUDE.md, docs/agents/runtime-registry.md, runtime-auth-model.md, implementation-policy.md, control-commands.md, codex-handoff.md, bootstrap-command.md, .claude/commands/shiki.md, .codex/skills/shiki/SKILL.md). Commit decision records: ADR 0008, ADR 0009, CONTEXT.md glossary (Requirements Definition, Spec Freeze, Spec Amendment, Assumption Log). Guardian-approved implementation by Claude Code in this assigned task.

## Non-goals
- No spec_freeze plan contract changes (G-C)
- No autonomous loop or auto-merge (G-D)
- No KNOWN_SKILLS or code-review skill changes (G-B)
- runner codex remains supported and tested

## Acceptance
- bash scripts/test_shiki_runner_claude.sh passes: a ready claude-code task dispatches through a fake claude binary into the materialized registered worktree with EXEC record, ledger evidence, and review status
- bash scripts/test_shiki_runner_codex.sh still passes with the adapter-extracted machinery
- python3 scripts/validate_shiki.py passes with claude-code implementer/runner roles, implementer: claude-code config, and the new module in SHIKI_CLI_MODULE_FILES
- python3 -m unittest discover -s tests passes including tests/test_runner_adapters.py
- bash scripts/test_shiki_runtime_registry.sh and bash scripts/test_shiki_module_boundaries.sh pass with the extended role grants and new module
- All scripts/test_shiki_*.sh and CI (Validate / Claude review / CCA / MergeGate) pass

## Evidence
- python3 scripts/validate_shiki.py

## Ledger evidence
- L-20260612T045923587248Z-2afe1f72
- L-20260612T045948147001Z-2f69d634
- L-20260612T045958617603Z-049aab6f
- L-20260612T045958694223Z-f313daa5
- L-20260612T045958766095Z-1e97b822
- L-20260612T053259839357Z-a2d2be2c
- L-20260612T053349378376Z-3d70c7ec
- L-20260612T053540157300Z-b0df682e
- L-20260612T053540158176Z-1e1a7626
- L-20260612T054443696606Z-7ecda253
- L-20260612T054443779008Z-a798112a
- L-20260612T054500706823Z-82551799

## MergeGate
- Locks: path:scripts/shiki_runtime.py, path:scripts/shiki_runtime_adapters.py, path:scripts/shiki_runtime_registry.py, path:scripts/shiki_cli.py, path:scripts/shiki_installer.py, path:scripts/shiki_tasks.py, path:scripts/validate_shiki.py, path:scripts/test_shiki_*.sh, path:tests/*, path:.shiki/**, path:docs/**, path:AGENTS.md, path:CLAUDE.md, path:CONTEXT.md, path:.claude/commands/shiki.md, path:.codex/skills/shiki/SKILL.md, path:README.md, path:SYSTEM_PROMPT.md
- Risk: medium
- CCA required: yes
