### PR TITLE
T-20260612T055157606542Z-5205e0bd: Register code-review as a Skill Gate skill and make it the default pre-PR implementer gate

### DIFF
--- a/.shiki/goals/G-20260612T055133628076Z-d76238aa.json
+++ b/.shiki/goals/G-20260612T055133628076Z-d76238aa.json
@@ -13,6 +13,9 @@
   "created_at": "2026-06-12T05:51:33+00:00",
   "github_issue": 119,
   "id": "G-20260612T055133628076Z-d76238aa",
+  "ledger_evidence": [
+    "L-20260612T061938064648Z-2370dfe9"
+  ],
   "non_goals": [
     "No spec_freeze or /shiki Goal mode changes (G-C)",
     "No autonomous loop changes (G-D)",
@@ -24,6 +27,6 @@
     "tdd"
   ],
   "risk_level": "medium",
-  "status": "planned",
+  "status": "complete",
   "title": "G-B: mandatory pre-PR code-review gate via Skill Gate and skill-evidence enforcement"
 }

--- a/.shiki/ledger/L-20260612T061937982408Z-a64cd940.json
+++ b/.shiki/ledger/L-20260612T061937982408Z-a64cd940.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/tasks/T-20260612T055157606542Z-5205e0bd.json"
+  ],
+  "goal_id": "G-20260612T055133628076Z-d76238aa",
+  "id": "L-20260612T061937982408Z-a64cd940",
+  "links": [],
+  "summary": "Task T-20260612T055157606542Z-5205e0bd status changed to done",
+  "task_id": "T-20260612T055157606542Z-5205e0bd",
+  "timestamp": "2026-06-12T06:19:37+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260612T061938064648Z-2370dfe9.json
+++ b/.shiki/ledger/L-20260612T061938064648Z-2370dfe9.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/reports/R-20260612T061938063729Z-e7cc1c5f.json"
+  ],
+  "goal_id": "G-20260612T055133628076Z-d76238aa",
+  "id": "L-20260612T061938064648Z-2370dfe9",
+  "links": [],
+  "summary": "G-B complete: code-review is a Skill Gate skill and the default pre-PR implementer gate, enforced by MergeGate skill evidence; merged as PR #122",
+  "task_id": null,
+  "timestamp": "2026-06-12T06:19:38+00:00",
+  "type": "completion"
+}

--- a/.shiki/ledger/L-20260612T061955638439Z-5511f4ee.json
+++ b/.shiki/ledger/L-20260612T061955638439Z-5511f4ee.json
@@ -1,0 +1,15 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    "https://github.com/mizutani-140/shiki/pull/123"
+  ],
+  "goal_id": "G-20260612T055133628076Z-d76238aa",
+  "id": "L-20260612T061955638439Z-5511f4ee",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/123"
+  ],
+  "summary": "GitHub PR #123 created for T-20260612T055157606542Z-5205e0bd",
+  "task_id": "T-20260612T055157606542Z-5205e0bd",
+  "timestamp": "2026-06-12T06:19:55+00:00",
+  "type": "handoff"
+}

--- a/.shiki/locks/T-20260612T055157606542Z-5205e0bd.json
+++ b/.shiki/locks/T-20260612T055157606542Z-5205e0bd.json
@@ -17,6 +17,6 @@
     "path:.github/prompts/*"
   ],
   "owner": "shiki-cli",
-  "state": "active",
+  "state": "released",
   "task_id": "T-20260612T055157606542Z-5205e0bd"
 }

--- a/.shiki/reports/R-20260612T061938063729Z-e7cc1c5f.json
+++ b/.shiki/reports/R-20260612T061938063729Z-e7cc1c5f.json
@@ -1,0 +1,19 @@
+{
+  "blocking_reasons": [],
+  "created_at": "2026-06-12T06:19:38+00:00",
+  "evidence": [
+    ".shiki/tasks/T-20260612T055157606542Z-5205e0bd.json"
+  ],
+  "goal_id": "G-20260612T055133628076Z-d76238aa",
+  "id": "R-20260612T061938063729Z-e7cc1c5f",
+  "mergegate": {
+    "checks": "pass",
+    "dependencies": "pass",
+    "ledger": "pass",
+    "locks": "pass",
+    "review": "recorded",
+    "risk": "medium"
+  },
+  "status": "complete",
+  "summary": "G-B complete: code-review is a Skill Gate skill and the default pre-PR implementer gate, enforced by MergeGate skill evidence; merged as PR #122"
+}

--- a/.shiki/tasks/T-20260612T055157606542Z-5205e0bd.json
+++ b/.shiki/tasks/T-20260612T055157606542Z-5205e0bd.json
@@ -8,7 +8,7 @@
   "assigned_runtime": "claude-code",
   "dependencies": [],
   "expected_branch": "shiki/t-5205e0bd-post-merge-reconcile",
-  "expected_pr": 122,
+  "expected_pr": 123,
   "github_issue": 119,
   "goal_id": "G-20260612T055133628076Z-d76238aa",
   "id": "T-20260612T055157606542Z-5205e0bd",
@@ -24,7 +24,8 @@
     "L-20260612T061357114114Z-62e3eae1",
     "L-20260612T061456787131Z-2d295936",
     "L-20260612T061937982408Z-a64cd940",
-    "L-20260612T061938064648Z-2370dfe9"
+    "L-20260612T061938064648Z-2370dfe9",
+    "L-20260612T061955638439Z-5511f4ee"
   ],
   "locks": [
     "path:scripts/validate_shiki.py",

--- a/.shiki/tasks/T-20260612T055157606542Z-5205e0bd.json
+++ b/.shiki/tasks/T-20260612T055157606542Z-5205e0bd.json
@@ -7,7 +7,7 @@
   ],
   "assigned_runtime": "claude-code",
   "dependencies": [],
-  "expected_branch": "shiki/g-d76238aa-code-review-gate",
+  "expected_branch": "shiki/t-5205e0bd-post-merge-reconcile",
   "expected_pr": 122,
   "github_issue": 119,
   "goal_id": "G-20260612T055133628076Z-d76238aa",
@@ -22,7 +22,9 @@
     "L-20260612T061357037513Z-12b3b43a",
     "L-20260612T061357037912Z-fc64fcb4",
     "L-20260612T061357114114Z-62e3eae1",
-    "L-20260612T061456787131Z-2d295936"
+    "L-20260612T061456787131Z-2d295936",
+    "L-20260612T061937982408Z-a64cd940",
+    "L-20260612T061938064648Z-2370dfe9"
   ],
   "locks": [
     "path:scripts/validate_shiki.py",
@@ -51,6 +53,6 @@
   ],
   "risk_level": "medium",
   "scope": "Add skills/engineering/code-review/SKILL.md (wrapper: run the native code-review skill after TDD green and before PR creation, apply fixes as the implementer on the task branch, record findings+resolutions as a ledger entry whose summary names the skill and as a PR body section). Extend validate_shiki.py KNOWN_SKILLS, .shiki/schemas/repair-packet.schema.json required_skill enum, and shiki_cli.py repair --required-skill choices with code-review. Flip default required_skills to [tdd, code-review] in shiki_tasks.register_task_from_plan and shiki_bootstrap start synthesis so MergeGate's existing skill-evidence rule enforces the gate on every new task. Document the contract: skill-gate.md row + quick map, AGENTS.md Skill Gate table row, checklists.md PR-12 item, triage-labels.md skill:code-review, implementation-policy.md implementer contract (TDD -> code-review -> PR), CLAUDE.md handoff standard line. Add scripts/test_shiki_code_review_gate.sh (plan task and repair packet carrying code-review pass validation; SKILL.md staged) and register it in installer TEMPLATE_PATHS. Guardian-approved implementation by Claude Code in this assigned task.",
-  "status": "review",
+  "status": "done",
   "title": "Register code-review as a Skill Gate skill and make it the default pre-PR implementer gate"
 }

--- a/.shiki/worktrees/T-20260612T055157606542Z-5205e0bd.json
+++ b/.shiki/worktrees/T-20260612T055157606542Z-5205e0bd.json
@@ -17,7 +17,7 @@
     "path:CLAUDE.md"
   ],
   "path": "/Users/kio.mizutani/shiki",
-  "pr": 122,
+  "pr": 123,
   "runtime": "claude-code",
   "state": "registered",
   "task_id": "T-20260612T055157606542Z-5205e0bd"


### PR DESCRIPTION
## Shiki
Goal: G-20260612T055133628076Z-d76238aa
Task: T-20260612T055157606542Z-5205e0bd
CCA checklist profile: PR, TDD, V, CCA

## Scope
Add skills/engineering/code-review/SKILL.md (wrapper: run the native code-review skill after TDD green and before PR creation, apply fixes as the implementer on the task branch, record findings+resolutions as a ledger entry whose summary names the skill and as a PR body section). Extend validate_shiki.py KNOWN_SKILLS, .shiki/schemas/repair-packet.schema.json required_skill enum, and shiki_cli.py repair --required-skill choices with code-review. Flip default required_skills to [tdd, code-review] in shiki_tasks.register_task_from_plan and shiki_bootstrap start synthesis so MergeGate's existing skill-evidence rule enforces the gate on every new task. Document the contract: skill-gate.md row + quick map, AGENTS.md Skill Gate table row, checklists.md PR-12 item, triage-labels.md skill:code-review, implementation-policy.md implementer contract (TDD -> code-review -> PR), CLAUDE.md handoff standard line. Add scripts/test_shiki_code_review_gate.sh (plan task and repair packet carrying code-review pass validation; SKILL.md staged) and register it in installer TEMPLATE_PATHS. Guardian-approved implementation by Claude Code in this assigned task.

## Non-goals
- No spec_freeze or /shiki Goal mode changes (G-C)
- No autonomous loop changes (G-D)
- No workflow YAML or required-check changes

## Acceptance
- bash scripts/test_shiki_code_review_gate.sh passes: a plan task with required_skills [tdd, code-review] orchestrates and validates; a repair packet with --required-skill code-review passes schema validation; a task registered without explicit skills defaults to [tdd, code-review]
- python3 scripts/validate_shiki.py passes with the extended KNOWN_SKILLS and the new SKILL.md present
- All scripts/test_shiki_*.sh, python3 -m unittest discover -s tests, and CI (Validate / Claude review / CCA / MergeGate) pass
- This PR itself carries pre-PR code-review ledger evidence (dogfood of the new gate)

## Evidence
- python3 scripts/validate_shiki.py

## Ledger evidence
- L-20260612T055157606860Z-e37dd972
- L-20260612T055157688695Z-4e95c2bf
- L-20260612T055157762371Z-0b1b9738
- L-20260612T055133628737Z-55b7d606
- L-20260612T055157836849Z-bfdb5f92
- L-20260612T061357036867Z-e2fff40f
- L-20260612T061357037513Z-12b3b43a
- L-20260612T061357037912Z-fc64fcb4
- L-20260612T061357114114Z-62e3eae1
- L-20260612T061456787131Z-2d295936
- L-20260612T061937982408Z-a64cd940
- L-20260612T061938064648Z-2370dfe9
- L-20260612T061955638439Z-5511f4ee

## MergeGate
- Locks: path:scripts/validate_shiki.py, path:scripts/shiki_cli.py, path:scripts/shiki_tasks.py, path:scripts/shiki_bootstrap.py, path:scripts/shiki_installer.py, path:scripts/test_shiki_*.sh, path:.shiki/**, path:skills/engineering/**, path:docs/**, path:AGENTS.md, path:CLAUDE.md, path:CONTEXT.md, path:.github/prompts/*
- Risk: medium
- CCA required: yes

## Pre-PR code review
Evidence-only post-merge reconcile of .shiki state (lock release, task done, goal complete) — exception class 'pure .shiki state reconciliation' per skills/engineering/code-review/SKILL.md; recorded here per PR-12.

