### PR TITLE
T-20260612T091329543362Z-778e0c2f: Goal loop engine, repair dispatch via runner --repair-id, doctor unregistered-worktree check, version 0.2.0

### DIFF
--- a/.shiki/goals/G-20260612T091302245408Z-d0c43361.json
+++ b/.shiki/goals/G-20260612T091302245408Z-d0c43361.json
@@ -13,6 +13,9 @@
   "created_at": "2026-06-12T09:13:02+00:00",
   "github_issue": 119,
   "id": "G-20260612T091302245408Z-d0c43361",
+  "ledger_evidence": [
+    "L-20260612T100954807006Z-97dd6399"
+  ],
   "non_goals": [
     "No target-repo migration application (separate follow-up Goal)",
     "No workflow YAML or required-check changes",
@@ -25,6 +28,6 @@
     "code-review"
   ],
   "risk_level": "medium",
-  "status": "planned",
+  "status": "complete",
   "title": "G-D: autonomous post-freeze goal loop, repair dispatch, doctor worktree check, release 0.2.0"
 }

--- a/.shiki/ledger/L-20260612T100954725469Z-59967af1.json
+++ b/.shiki/ledger/L-20260612T100954725469Z-59967af1.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/tasks/T-20260612T091329543362Z-778e0c2f.json"
+  ],
+  "goal_id": "G-20260612T091302245408Z-d0c43361",
+  "id": "L-20260612T100954725469Z-59967af1",
+  "links": [],
+  "summary": "Task T-20260612T091329543362Z-778e0c2f status changed to done",
+  "task_id": "T-20260612T091329543362Z-778e0c2f",
+  "timestamp": "2026-06-12T10:09:54+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260612T100954807006Z-97dd6399.json
+++ b/.shiki/ledger/L-20260612T100954807006Z-97dd6399.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/reports/R-20260612T100954806085Z-d598f4dd.json"
+  ],
+  "goal_id": "G-20260612T091302245408Z-d0c43361",
+  "id": "L-20260612T100954807006Z-97dd6399",
+  "links": [],
+  "summary": "G-D complete: shiki loop drives frozen Goals autonomously (risk-gated auto-merge, bounded repair, CCA rerun, dependent unblocking), runners dispatch repair handoffs, doctor flags unregistered worktrees, platform version 0.2.0; merged as PR #126",
+  "task_id": null,
+  "timestamp": "2026-06-12T10:09:54+00:00",
+  "type": "completion"
+}

--- a/.shiki/ledger/L-20260612T101016649437Z-6f142beb.json
+++ b/.shiki/ledger/L-20260612T101016649437Z-6f142beb.json
@@ -1,0 +1,15 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    "https://github.com/mizutani-140/shiki/pull/127"
+  ],
+  "goal_id": "G-20260612T091302245408Z-d0c43361",
+  "id": "L-20260612T101016649437Z-6f142beb",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/127"
+  ],
+  "summary": "GitHub PR #127 created for T-20260612T091329543362Z-778e0c2f",
+  "task_id": "T-20260612T091329543362Z-778e0c2f",
+  "timestamp": "2026-06-12T10:10:16+00:00",
+  "type": "handoff"
+}

--- a/.shiki/locks/T-20260612T091329543362Z-778e0c2f.json
+++ b/.shiki/locks/T-20260612T091329543362Z-778e0c2f.json
@@ -25,6 +25,6 @@
     "path:CONTEXT.md"
   ],
   "owner": "shiki-cli",
-  "state": "active",
+  "state": "released",
   "task_id": "T-20260612T091329543362Z-778e0c2f"
 }

--- a/.shiki/reports/R-20260612T100954806085Z-d598f4dd.json
+++ b/.shiki/reports/R-20260612T100954806085Z-d598f4dd.json
@@ -1,0 +1,19 @@
+{
+  "blocking_reasons": [],
+  "created_at": "2026-06-12T10:09:54+00:00",
+  "evidence": [
+    ".shiki/tasks/T-20260612T091329543362Z-778e0c2f.json"
+  ],
+  "goal_id": "G-20260612T091302245408Z-d0c43361",
+  "id": "R-20260612T100954806085Z-d598f4dd",
+  "mergegate": {
+    "checks": "pass",
+    "dependencies": "pass",
+    "ledger": "pass",
+    "locks": "pass",
+    "review": "recorded",
+    "risk": "medium"
+  },
+  "status": "complete",
+  "summary": "G-D complete: shiki loop drives frozen Goals autonomously (risk-gated auto-merge, bounded repair, CCA rerun, dependent unblocking), runners dispatch repair handoffs, doctor flags unregistered worktrees, platform version 0.2.0; merged as PR #126"
+}

--- a/.shiki/tasks/T-20260612T091329543362Z-778e0c2f.json
+++ b/.shiki/tasks/T-20260612T091329543362Z-778e0c2f.json
@@ -9,7 +9,7 @@
   ],
   "assigned_runtime": "claude-code",
   "dependencies": [],
-  "expected_branch": "shiki/g-d0c43361-goal-loop",
+  "expected_branch": "shiki/t-778e0c2f-post-merge-reconcile",
   "expected_pr": 126,
   "github_issue": 119,
   "goal_id": "G-20260612T091302245408Z-d0c43361",
@@ -24,7 +24,9 @@
     "L-20260612T095525697560Z-30ef1878",
     "L-20260612T095525697968Z-18241955",
     "L-20260612T095525778113Z-e465f399",
-    "L-20260612T095549373205Z-b4b28a6d"
+    "L-20260612T095549373205Z-b4b28a6d",
+    "L-20260612T100954725469Z-59967af1",
+    "L-20260612T100954807006Z-97dd6399"
   ],
   "locks": [
     "path:scripts/shiki_loop.py",
@@ -61,6 +63,6 @@
   ],
   "risk_level": "medium",
   "scope": "New module scripts/shiki_loop.py: pure decision engine decide_task_action(snapshot)->action covering dispatch / create_pr / wait_checks / rerun_cca (CCA failed while other required checks passed or pending->green) / merge (all required checks green AND risk low|medium) / stop_guardian (risk high|critical at merge time, or repair attempts exhausted) / dispatch_repair (required check failed, bounded by automatic_repair_limit) / unblock_dependents and goal_complete; effectors separated (gh pr checks/view/merge via run(), runner dispatch, repair packet + handoff creation, task status + ledger evidence). CLI: shiki loop step --goal-id and shiki loop run --goal-id --max-cycles --interval wired in shiki_cli.py. Runner: dispatch_runner_task accepts --repair-id (handoffs/RP-x-repair.md). Doctor: new finding doctor.worktrees.unregistered comparing git worktree list against .shiki/worktrees registry. Version: VERSION and pyproject.toml to 0.2.0. Sync: installer TEMPLATE_PATHS, validator SHIKI_CLI_MODULE_FILES, module-boundary/staging lists; tests tests/test_loop_engine.py (fixture unit tests for every action branch) and scripts/test_shiki_goal_loop.sh (fake gh + fake claude end-to-end: dispatch -> PR -> checks green -> auto-merge -> dependent unblock -> goal complete; plus high-risk stop and repair-limit stop). Docs: control-commands loop section, implementation-policy coordinator loop, /shiki Goal mode step references shiki loop run, AGENTS.md MergeGate auto-merge sentence (risk low/medium with full evidence; high/critical stays Guardian-gated). Guardian-approved implementation by Claude Code in this assigned task.",
-  "status": "review",
+  "status": "done",
   "title": "Goal loop engine, repair dispatch via runner --repair-id, doctor unregistered-worktree check, version 0.2.0"
 }

--- a/.shiki/tasks/T-20260612T091329543362Z-778e0c2f.json
+++ b/.shiki/tasks/T-20260612T091329543362Z-778e0c2f.json
@@ -10,7 +10,7 @@
   "assigned_runtime": "claude-code",
   "dependencies": [],
   "expected_branch": "shiki/t-778e0c2f-post-merge-reconcile",
-  "expected_pr": 126,
+  "expected_pr": 127,
   "github_issue": 119,
   "goal_id": "G-20260612T091302245408Z-d0c43361",
   "id": "T-20260612T091329543362Z-778e0c2f",
@@ -26,7 +26,8 @@
     "L-20260612T095525778113Z-e465f399",
     "L-20260612T095549373205Z-b4b28a6d",
     "L-20260612T100954725469Z-59967af1",
-    "L-20260612T100954807006Z-97dd6399"
+    "L-20260612T100954807006Z-97dd6399",
+    "L-20260612T101016649437Z-6f142beb"
   ],
   "locks": [
     "path:scripts/shiki_loop.py",

--- a/.shiki/worktrees/T-20260612T091329543362Z-778e0c2f.json
+++ b/.shiki/worktrees/T-20260612T091329543362Z-778e0c2f.json
@@ -25,7 +25,7 @@
     "path:pyproject.toml"
   ],
   "path": "/Users/kio.mizutani/shiki",
-  "pr": 126,
+  "pr": 127,
   "runtime": "claude-code",
   "state": "registered",
   "task_id": "T-20260612T091329543362Z-778e0c2f"


### PR DESCRIPTION
## Shiki
Goal: G-20260612T091302245408Z-d0c43361
Task: T-20260612T091329543362Z-778e0c2f
CCA checklist profile: PR, TDD, V, CCA

## Scope
New module scripts/shiki_loop.py: pure decision engine decide_task_action(snapshot)->action covering dispatch / create_pr / wait_checks / rerun_cca (CCA failed while other required checks passed or pending->green) / merge (all required checks green AND risk low|medium) / stop_guardian (risk high|critical at merge time, or repair attempts exhausted) / dispatch_repair (required check failed, bounded by automatic_repair_limit) / unblock_dependents and goal_complete; effectors separated (gh pr checks/view/merge via run(), runner dispatch, repair packet + handoff creation, task status + ledger evidence). CLI: shiki loop step --goal-id and shiki loop run --goal-id --max-cycles --interval wired in shiki_cli.py. Runner: dispatch_runner_task accepts --repair-id (handoffs/RP-x-repair.md). Doctor: new finding doctor.worktrees.unregistered comparing git worktree list against .shiki/worktrees registry. Version: VERSION and pyproject.toml to 0.2.0. Sync: installer TEMPLATE_PATHS, validator SHIKI_CLI_MODULE_FILES, module-boundary/staging lists; tests tests/test_loop_engine.py (fixture unit tests for every action branch) and scripts/test_shiki_goal_loop.sh (fake gh + fake claude end-to-end: dispatch -> PR -> checks green -> auto-merge -> dependent unblock -> goal complete; plus high-risk stop and repair-limit stop). Docs: control-commands loop section, implementation-policy coordinator loop, /shiki Goal mode step references shiki loop run, AGENTS.md MergeGate auto-merge sentence (risk low/medium with full evidence; high/critical stays Guardian-gated). Guardian-approved implementation by Claude Code in this assigned task.

## Non-goals
- No target migration application
- No workflow YAML changes
- No Guardian policy changes

## Acceptance
- bash scripts/test_shiki_goal_loop.sh passes: fake-runtime goal drives dispatch -> PR -> green checks -> auto-merge -> dependent unblock -> goal complete; high/critical risk stops for guardian; repair dispatch stops after the attempt limit
- python3 -m unittest discover -s tests passes including tests/test_loop_engine.py covering every decision branch
- shiki runner claude --repair-id dispatches a repair handoff in the runner contract tests
- shiki doctor flags an unregistered git worktree in test_shiki_doctor.sh
- VERSION and pyproject.toml read 0.2.0; python3 scripts/validate_shiki.py and all scripts/test_shiki_*.sh pass; CI (Validate / Claude review / CCA / MergeGate) green
- This PR carries pre-PR code-review ledger evidence (PR-12)

## Evidence
- python3 scripts/validate_shiki.py

## Ledger evidence
- L-20260612T091329543588Z-9cbc1742
- L-20260612T091329629310Z-c03801dc
- L-20260612T091329709249Z-6343ff50
- L-20260612T091302246267Z-1d948ad0
- L-20260612T091329785073Z-d1d74907
- L-20260612T095525696735Z-08fdceda
- L-20260612T095525697560Z-30ef1878
- L-20260612T095525697968Z-18241955
- L-20260612T095525778113Z-e465f399
- L-20260612T095549373205Z-b4b28a6d
- L-20260612T100954725469Z-59967af1
- L-20260612T100954807006Z-97dd6399
- L-20260612T101016649437Z-6f142beb

## MergeGate
- Locks: path:scripts/shiki_loop.py, path:scripts/shiki_runtime.py, path:scripts/shiki_cli.py, path:scripts/shiki_doctor.py, path:scripts/shiki_installer.py, path:scripts/validate_shiki.py, path:scripts/test_shiki_*.sh, path:tests/*, path:.shiki/**, path:docs/**, path:AGENTS.md, path:CLAUDE.md, path:README.md, path:SYSTEM_PROMPT.md, path:CONTRIBUTING.md, path:.claude/commands/shiki.md, path:.codex/skills/shiki/SKILL.md, path:VERSION, path:pyproject.toml, path:scripts/shiki_tasks.py, path:CONTEXT.md
- Risk: medium
- CCA required: yes

## Pre-PR code review
Evidence-only post-merge reconcile of .shiki state (lock release, task done, goal complete) — exception class 'pure .shiki state reconciliation' per skills/engineering/code-review/SKILL.md; recorded here per PR-12.

