### PR TITLE
T1 stale post-merge lock reconcile (release lock, clear expected_pr)

### DIFF
--- a/.shiki/ledger/L-20260615T010503358988Z-021a8cf6.json
+++ b/.shiki/ledger/L-20260615T010503358988Z-021a8cf6.json
@@ -7,9 +7,10 @@
   "goal_id": "G-20260612T152357704854Z-8a5508cf",
   "id": "L-20260615T010503358988Z-021a8cf6",
   "links": [
-    "https://github.com/mizutani-140/shiki/pull/129"
+    "https://github.com/mizutani-140/shiki/pull/129",
+    "https://github.com/mizutani-140/shiki/pull/133"
   ],
-  "summary": "Stale post-merge reconcile: T1 PR #129 merged (commit cc616d0) without the loop releasing the lock; releasing the T1 lock and clearing expected_pr so dependent control-plane work is unblocked. T1 is NOT marked done here (closeout is a separate PR).",
+  "summary": "Stale post-merge reconcile: T1 PR #129 merged (commit cc616d0) without the loop releasing the lock; releasing the T1 lock and clearing expected_pr so dependent control-plane work is unblocked. T1 is NOT marked done here (closeout is a separate PR) (reconcile delivered via PR #133).",
   "task_id": "T-20260612T152357706392Z-75f529da",
   "timestamp": "2026-06-15T01:05:03+00:00",
   "type": "lock"

--- a/.shiki/ledger/L-20260615T010503358988Z-021a8cf6.json
+++ b/.shiki/ledger/L-20260615T010503358988Z-021a8cf6.json
@@ -1,0 +1,16 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/locks/T-20260612T152357706392Z-75f529da.json",
+    ".shiki/tasks/T-20260612T152357706392Z-75f529da.json"
+  ],
+  "goal_id": "G-20260612T152357704854Z-8a5508cf",
+  "id": "L-20260615T010503358988Z-021a8cf6",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/129"
+  ],
+  "summary": "Stale post-merge reconcile: T1 PR #129 merged (commit cc616d0) without the loop releasing the lock; releasing the T1 lock and clearing expected_pr so dependent control-plane work is unblocked. T1 is NOT marked done here (closeout is a separate PR).",
+  "task_id": "T-20260612T152357706392Z-75f529da",
+  "timestamp": "2026-06-15T01:05:03+00:00",
+  "type": "lock"
+}

--- a/.shiki/locks/T-20260612T152357706392Z-75f529da.json
+++ b/.shiki/locks/T-20260612T152357706392Z-75f529da.json
@@ -15,6 +15,7 @@
     "path:docs/**"
   ],
   "owner": "shiki-run",
-  "state": "active",
-  "task_id": "T-20260612T152357706392Z-75f529da"
+  "state": "released",
+  "task_id": "T-20260612T152357706392Z-75f529da",
+  "released_at": "2026-06-15T01:05:03+00:00"
 }

--- a/.shiki/tasks/T-20260612T152357706392Z-75f529da.json
+++ b/.shiki/tasks/T-20260612T152357706392Z-75f529da.json
@@ -7,8 +7,8 @@
   ],
   "assigned_runtime": "claude-code",
   "dependencies": [],
-  "expected_branch": "shiki/t-20260612t152357706392z-75f529da-memory-state-foundation",
-  "expected_pr": 129,
+  "expected_branch": "shiki/t1-lock-reconcile",
+  "expected_pr": null,
   "github_issue": null,
   "goal_id": "G-20260612T152357704854Z-8a5508cf",
   "id": "T-20260612T152357706392Z-75f529da",
@@ -25,7 +25,8 @@
     "L-20260613T015343657647Z-a0a77ad0",
     "L-20260613T015525020346Z-9c716ad4",
     "L-20260613T022924287537Z-06fe8144",
-    "L-20260613T070335944116Z-c369a581"
+    "L-20260613T070335944116Z-c369a581",
+    "L-20260615T010503358988Z-021a8cf6"
   ],
   "locks": [
     "path:.shiki/**",


### PR DESCRIPTION
## Shiki
Task: T-20260612T152357706392Z-75f529da
Goal: G-20260612T152357704854Z-8a5508cf
CCA checklist profile: PR, V
Risk: high

## Scope
Gated, T1-scoped state reconcile of a stale post-merge residue. T1 (memory state
foundation) merged in PR #129 (commit cc616d0) without the autonomous loop
releasing its lock, so the residual active lock (path:.shiki/**, validate_shiki.py,
tests/*) and stale expected_pr=129 / expected_branch block all later control-plane
work (including the platform-fix PR #132). This PR:
- releases the T1 lock (state=released, released_at);
- clears the merged-PR residue on the task (expected_pr=null, expected_branch
  retargeted to this branch);
- appends a task-scoped reconcile ledger.

## Non-goals
- T1 is NOT marked done (closeout is a separate PR).
- No DAG change, no T2/T3 registration, no goal-complete report.
- No code, no authority artifacts, no memories/distilled rules, no reports.

## Acceptance
- Only T1's own lock + task residue + a T1-scoped ledger change (3 files).
- validate_shiki.py passes; MergeGate metadata is ready (only the expected_pr
  warning); no goal-complete is required (T1 is not done).

## Evidence
- python3 scripts/validate_shiki.py

## MergeGate
High-risk state reconcile. Merges only with an independent Guardian authority
(external AI guardian review artifact, ADR 0010, head-SHA bound) or the human
guardian path. This is a normal task-scoped PR (no relaxed mode); the new
goal_reconcile / post_merge_reconcile PR types live in PR #132 and are not relied
on here.
