### PR TITLE
T3: Consult injection and docs (proposal 0001 v2 §3.5 + §3.7)

### DIFF
--- a/.claude/commands/shiki.md
+++ b/.claude/commands/shiki.md
@@ -130,6 +130,7 @@ the selected skills directory in the start record, plan, and handoff evidence.
 
 ## Operating Rules
 
+- At session start, read active distilled rules from `.shiki/memories/` (status `distilled`, `active: true`, not revoked or superseded) for applicable guidance; the same rules are injected deterministically into task handoffs as the `## Distilled Rules` section (§3.5).
 - Treat the assigned implementer runtime (Claude Code by default, Codex when assigned) as implementer, CCA as completion judge, and MergeGate as merge authorization.
 - Treat `/shiki` as a guided one-command entrypoint. Do not ask the user to run multiple setup commands.
 - For non-trivial goals, use `grill-with-docs`, then Context and Impact, then PRD/issues/triage.

--- a/.shiki/ledger/L-20260615T124011081676Z-89172cca.json
+++ b/.shiki/ledger/L-20260615T124011081676Z-89172cca.json
@@ -1,0 +1,13 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/tasks/T-20260612T152357707653Z-e200274d.json"
+  ],
+  "goal_id": "G-20260612T152357704854Z-8a5508cf",
+  "id": "L-20260615T124011081676Z-89172cca",
+  "links": [],
+  "summary": "T3 Context & Impact: 5-agent Workflow exploration sweep (CI-08) over proposal 0001 v2 \u00a73.5/\u00a73.7 vs current main. CI-08 assumption (operator-approved, NOT a spec amendment): the frozen spec selects distilled rules on task.area/goal.area but neither the task nor goal schema defines area/tags; T3 implements those operands as a DERIVED, non-persisted consult context computed from task lock paths (->areas) and required_skills (->tags). No task/goal schema change; a test asserts the schemas do not gain area/tags. Plan spec_freeze.amendments stays empty.",
+  "task_id": "T-20260612T152357707653Z-e200274d",
+  "timestamp": "2026-06-15T12:40:11.081676+00:00",
+  "type": "context-impact"
+}

--- a/.shiki/ledger/L-20260615T124011083651Z-c9a43f50.json
+++ b/.shiki/ledger/L-20260615T124011083651Z-c9a43f50.json
@@ -1,0 +1,13 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/tasks/T-20260612T152357707653Z-e200274d.json"
+  ],
+  "goal_id": "G-20260612T152357704854Z-8a5508cf",
+  "id": "L-20260615T124011083651Z-c9a43f50",
+  "links": [],
+  "summary": "Skill tdd: red-green-refactor for the Consult selector and handoff injection \u2014 failing tests written first in tests/test_memory_consult.py and tests/test_handoff_consult.py (deterministic injection with MEM ids, revoked/superseded/inactive/zero-selector exclusion, none-applicable, stable sort last_verified desc/id asc, no-mutation, no-schema-change, regeneration), then minimal implementation in scripts/shiki_memory.py + shiki_tasks.py + shiki_loop.py. 217 unit tests + 32 shell contract tests + validate_shiki green.",
+  "task_id": "T-20260612T152357707653Z-e200274d",
+  "timestamp": "2026-06-15T12:40:11.083651+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260615T124011083774Z-5f942ca1.json
+++ b/.shiki/ledger/L-20260615T124011083774Z-5f942ca1.json
@@ -1,0 +1,13 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/tasks/T-20260612T152357707653Z-e200274d.json"
+  ],
+  "goal_id": "G-20260612T152357704854Z-8a5508cf",
+  "id": "L-20260615T124011083774Z-5f942ca1",
+  "links": [],
+  "summary": "Skill code-review: pre-PR adversarial multi-agent review (5 dimensions: selector correctness, handoff/cache, acceptance/tests, safety, docs/scope). Found 1 blocking (missing-goal crash in write_task_handoff \u2014 ShikiError escaped the goal-load guard), 3 major (stable-sort tiebreak unproven; revoked-alone exclusion unproven; failure-tolerance gap), and minors (symmetric normalization, doc symbol, extra tests). All fixed and regression-tested; 0 confirmed findings remain. Evidence: review against main...e150ca6.",
+  "task_id": "T-20260612T152357707653Z-e200274d",
+  "timestamp": "2026-06-15T12:40:11.083774+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260615T124011083875Z-d5de6168.json
+++ b/.shiki/ledger/L-20260615T124011083875Z-d5de6168.json
@@ -1,0 +1,15 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/tasks/T-20260612T152357707653Z-e200274d.json"
+  ],
+  "goal_id": "G-20260612T152357704854Z-8a5508cf",
+  "id": "L-20260615T124011083875Z-d5de6168",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/137"
+  ],
+  "summary": "T3 task-registered: reference PR #137 for the MergeGate self-reference check. Consult injection + docs implementation; required skills tdd and code-review exercised. T3 moves planned->review (not done); no goal-complete; no T1/T2 change.",
+  "task_id": "T-20260612T152357707653Z-e200274d",
+  "timestamp": "2026-06-15T12:40:11.083875+00:00",
+  "type": "check"
+}

--- a/.shiki/tasks/T-20260612T152357707653Z-e200274d.json
+++ b/.shiki/tasks/T-20260612T152357707653Z-e200274d.json
@@ -1,18 +1,30 @@
 {
-  "id": "T-20260612T152357707653Z-e200274d",
+  "acceptance_checks": [
+    "Active distilled rules are injected with MEM ids in deterministic order; revoked/superseded rules are never injected; none applicable is emitted when no rule matches (tests prove all three)",
+    "Handoffs regenerate on every dispatch; H-12 present in checklists.md with section-presence-only wording; session-start reads documented; glossary entries added",
+    "python3 scripts/validate_shiki.py and the full contract suite pass; CI green; PR carries PR-12 evidence"
+  ],
+  "assigned_runtime": "claude-code",
+  "cca_checklist_profile": [
+    "PR",
+    "TDD",
+    "V",
+    "CCA"
+  ],
+  "dependencies": [
+    "T-20260612T152357706392Z-75f529da"
+  ],
+  "expected_branch": "shiki/t3-consult-injection",
+  "expected_pr": 137,
   "goal_id": "G-20260612T152357704854Z-8a5508cf",
-  "title": "Consult injection and docs",
-  "status": "planned",
-  "scope": "Implement proposal 0001 v2 sections 3.5 and 3.7: write_task_handoff always emits a Distilled Rules section (none applicable explicit) selecting only active, non-superseded, non-revoked distilled rules matched on task.area/goal.area/applies_to/tags, stable-sorted last_verified desc then id asc, each with its MEM id; dispatch regenerates the handoff every time (remove the write-if-missing cache in shiki_loop and runner paths); add H-12 to docs/agents/checklists.md as blocking-when-applicable with the section-presence-only CCA wording from proposal 3.5; add session-start memory reading to .claude/commands/shiki.md and CLAUDE.md without touching the source-of-truth blocks; add CONTEXT.md glossary entries Memory, Distilled Rule, Scorecard; add a docs/agents memory document following ledger/state-classes conventions; update docs/agents/shiki-cli-architecture.md module table.",
-  "non_goals": [
-    "No CCA prompt changes",
-    "No capture changes (T2)"
+  "id": "T-20260612T152357707653Z-e200274d",
+  "ledger_evidence": [
+    "L-20260615T084806676650Z-f9b4121a",
+    "L-20260615T124011081676Z-89172cca",
+    "L-20260615T124011083651Z-c9a43f50",
+    "L-20260615T124011083774Z-5f942ca1",
+    "L-20260615T124011083875Z-d5de6168"
   ],
-  "required_skills": [
-    "tdd",
-    "code-review"
-  ],
-  "risk_level": "high",
   "locks": [
     "path:.shiki/**",
     "path:scripts/shiki_memory.py",
@@ -27,23 +39,16 @@
     "path:.claude/commands/shiki.md",
     "path:.codex/skills/shiki/SKILL.md"
   ],
-  "acceptance_checks": [
-    "Active distilled rules are injected with MEM ids in deterministic order; revoked/superseded rules are never injected; none applicable is emitted when no rule matches (tests prove all three)",
-    "Handoffs regenerate on every dispatch; H-12 present in checklists.md with section-presence-only wording; session-start reads documented; glossary entries added",
-    "python3 scripts/validate_shiki.py and the full contract suite pass; CI green; PR carries PR-12 evidence"
+  "non_goals": [
+    "No CCA prompt changes",
+    "No capture changes (T2)"
   ],
-  "assigned_runtime": "claude-code",
-  "dependencies": [
-    "T-20260612T152357706392Z-75f529da"
+  "required_skills": [
+    "tdd",
+    "code-review"
   ],
-  "expected_branch": "shiki/t-e200274d-placeholder",
-  "cca_checklist_profile": [
-    "PR",
-    "TDD",
-    "V",
-    "CCA"
-  ],
-  "ledger_evidence": [
-    "L-20260615T084806676650Z-f9b4121a"
-  ]
+  "risk_level": "high",
+  "scope": "Implement proposal 0001 v2 sections 3.5 and 3.7: write_task_handoff always emits a Distilled Rules section (none applicable explicit) selecting only active, non-superseded, non-revoked distilled rules matched on task.area/goal.area/applies_to/tags, stable-sorted last_verified desc then id asc, each with its MEM id; dispatch regenerates the handoff every time (remove the write-if-missing cache in shiki_loop and runner paths); add H-12 to docs/agents/checklists.md as blocking-when-applicable with the section-presence-only CCA wording from proposal 3.5; add session-start memory reading to .claude/commands/shiki.md and CLAUDE.md without touching the source-of-truth blocks; add CONTEXT.md glossary entries Memory, Distilled Rule, Scorecard; add a docs/agents memory document following ledger/state-classes conventions; update docs/agents/shiki-cli-architecture.md module table.",
+  "status": "review",
+  "title": "Consult injection and docs"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,11 @@ At the start of a Shiki session:
 1. Read `AGENTS.md`.
 2. Read `CONTEXT.md` and relevant ADRs.
 3. Read active `.shiki/` Goal/task/ledger state when present.
-4. Read the GitHub Issue or PR when the task is GitHub-backed.
-5. Identify your role: Planner, Reviewer, Completion Check Agent, Repairer, Implementer, or Guardian-assist.
-6. Identify required skills using the Skill Gate.
-7. State missing prerequisites before taking action.
+4. Read active distilled rules from `.shiki/memories/` (status `distilled`, `active: true`, not revoked or superseded) for applicable guidance; the same rules are injected deterministically into task handoffs as the `## Distilled Rules` section (§3.5).
+5. Read the GitHub Issue or PR when the task is GitHub-backed.
+6. Identify your role: Planner, Reviewer, Completion Check Agent, Repairer, Implementer, or Guardian-assist.
+7. Identify required skills using the Skill Gate.
+8. State missing prerequisites before taking action.
 
 If direct GitHub state and `.shiki/` disagree, surface the conflict and prefer GitHub until the mirror is repaired.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,6 +104,18 @@ _Avoid_: treating "human pressed the button" as the only valid authority, record
 A first-class Guardian approval authority (ADR 0010) by which an external AI reviewer authorizes autonomous merge of a high/critical-risk PR through a head-SHA-bound `external_ai_guardian_review` artifact, recorded with the AI reviewer's own model identity (reviewer_type=external_ai_model).
 _Avoid_: transforming an AI review into an operator approval, committed (forgeable) approval files, head-unbound approval
 
+**Memory**:
+A current-state document under `.shiki/memories/MEM-*.json` recording a learned fact, promoted fail-closed through `raw -> investigated -> verified -> distilled`; the audit trail lives in `memory_transition` ledger events, not the file. Captured automatically from repair, loop-stop, CCA-fail, and runner-fail points with redaction.
+_Avoid_: append-only log, storing raw command output or secrets, treating the file as the audit trail
+
+**Distilled Rule**:
+A `distilled`-status Memory carrying an operator-approved, generalized one-line `rule`, revocable and supersedable; only active, non-revoked, non-superseded distilled rules are injected into handoffs (Consult, §3.5).
+_Avoid_: unapproved rule, auto-distillation, a rule that mutates on consult
+
+**Scorecard**:
+The ledger-derived, machine-computed summary emitted in the goal-complete report (§3.6) with distillation suggestions; computed only from ledger/task/report state and never changes Memory status.
+_Avoid_: recomputing from live state, mutating memories, scorecard on stdout
+
 ## Example Dialogue
 
 Operator: "Create a Goal for the new intake workflow."

--- a/docs/agents/checklists.md
+++ b/docs/agents/checklists.md
@@ -105,6 +105,7 @@ Blocking values:
 | H-09 | Verification commands are included. | blocking |
 | H-10 | Evidence the implementer must produce is included. | blocking |
 | H-11 | Prohibited changes are stated. | blocking |
+| H-12 | The handoff includes a `## Distilled Rules` section that either lists the applicable active distilled rules (each with its MEM id) or states `none applicable`. CCA verifies only the section's presence and the applicable / none-applicable marker — never the rule selection or rule content (no double authority between distilled rules and checklists). | blocking when applicable |
 
 ## TDD — Implementation Checklist
 

--- a/docs/agents/memory.md
+++ b/docs/agents/memory.md
@@ -1,0 +1,79 @@
+# Memory Loop
+
+Shiki learns across Goals. Failures are captured automatically as redacted raw
+memories, promoted through machine-checked evidence to operator-approved
+distilled rules, injected deterministically into handoffs, and summarized in a
+ledger-derived scorecard at goal completion. This document describes the shipped
+behavior (proposal `docs/proposals/0001-memory-loop-spec-freeze-review.md`).
+
+## Memory entries
+
+A memory is a current-state document at `.shiki/memories/MEM-<id>.json`
+(`filename == id`, enforced by the validator). The audit trail is **not** the
+file — it is the append-only `memory_transition` ledger events. Schema:
+`.shiki/schemas/memory-entry.schema.json`; cross-file rules: `validate_memory`
+in `scripts/validate_shiki.py` (fail-closed).
+
+Key fields: `status`, `area` (coarse enum), `tags` (free strings), `applies_to`
+(Consult-target areas), `claim`, `evidence`, `source`, and the distilled-only
+lifecycle fields `rule`, `approved_by`, `approved_at`, `approval_ledger`,
+`active`, `supersedes`, `superseded_by`, `revoked_at`, `redaction`.
+
+## Promotion (fail-closed)
+
+```
+raw -> investigated -> verified -> distilled
+```
+
+No skipping. `verified` requires at least one local evidence reference
+(ledger / report / exec). `distilled` requires an operator approval
+(`approved_by` + `approval_ledger`) and is **refused in autonomous-execution
+context** (the runner/loop sets a context variable that `distill`/`revoke`/
+`supersede` check). CLI: `shiki memory capture | list | investigate | promote |
+distill | revoke | supersede`.
+
+## Capture (auto, redacted, fail-open)
+
+Four capture points write redacted raw memories without ever breaking the loop:
+repair (after guards), loop-stop, CCA-fail, and runner-fail (non-zero
+returncode). Captured memories store a short redacted claim plus structured
+evidence references only — never command-output bodies or secret-like tokens.
+Invalid capture writes nothing and warns.
+
+## Consult (deterministic injection, §3.5)
+
+`write_task_handoff` always emits a `## Distilled Rules` section. Selection
+(`select_distilled_rules` in `scripts/shiki_memory.py`) is a pure function:
+
+- eligible = `distilled` AND `active: true` AND `superseded_by: null` AND
+  `revoked_at: null`, carrying at least one selector (`area`/`applies_to`/`tags`);
+- a rule matches when its `area`/`applies_to` overlaps the derived **consult
+  context areas** or its `tags` overlap the derived **consult context tags**;
+- order: `last_verified` descending, then MEM id ascending (missing
+  `last_verified` sorts last);
+- each selected rule is printed with its MEM id; when nothing matches the
+  section says `none applicable`.
+
+The handoff is regenerated on every dispatch (no write-if-missing cache), so the
+injected rules are never stale. Reading never mutates memory state.
+
+**CI-08 assumption (operator-approved, not a spec amendment).** The frozen spec
+selects on `task.area` / `goal.area`, but the task and goal schemas define no
+`area`/`tags` field. Rather than amend those schemas, Shiki derives a
+non-persisted **consult context** from existing metadata: task lock paths map to
+coarse areas and `required_skills` map to tags. No `area`/`tags` field is added
+to task or goal records.
+
+`H-12` (`docs/agents/checklists.md`) makes the section blocking when applicable;
+CCA checks only the section's presence and the applicable / none-applicable
+marker — never the rule selection or content (no double authority between
+distilled rules and checklists). Session start (CLAUDE.md, `.claude/commands/
+shiki.md`) also reads active distilled rules directly.
+
+## Scorecard (ledger-derived, §3.6)
+
+`goal complete` emits a scorecard computed only from ledger / task / report
+state (ledger-id deduped, zeros + warnings for missing sources) plus
+distillation **suggestions**. Suggestions never change memory status, and the
+scorecard rides in the report file — `goal complete` stdout stays a single
+`json_get_last`-compatible JSON object.

--- a/docs/agents/memory.md
+++ b/docs/agents/memory.md
@@ -11,8 +11,9 @@ behavior (proposal `docs/proposals/0001-memory-loop-spec-freeze-review.md`).
 A memory is a current-state document at `.shiki/memories/MEM-<id>.json`
 (`filename == id`, enforced by the validator). The audit trail is **not** the
 file — it is the append-only `memory_transition` ledger events. Schema:
-`.shiki/schemas/memory-entry.schema.json`; cross-file rules: `validate_memory`
-in `scripts/validate_shiki.py` (fail-closed).
+`.shiki/schemas/memory-entry.schema.json`; cross-file rules are enforced by the
+memory-validation block in `scripts/validate_shiki.py`, which calls
+`memory_entry_errors` from `scripts/shiki_memory.py` (fail-closed).
 
 Key fields: `status`, `area` (coarse enum), `tags` (free strings), `applies_to`
 (Consult-target areas), `claim`, `evidence`, `source`, and the distilled-only

--- a/docs/agents/shiki-cli-architecture.md
+++ b/docs/agents/shiki-cli-architecture.md
@@ -22,6 +22,7 @@ command execution work at import time.
 | `scripts/shiki_migrations.py` | Dependency-free `.shiki` migration registry, state loading, status/plan/apply behavior, dry-run / execute gate, and migration CLI command implementation. |
 | `scripts/shiki_bootstrap.py` | `init`, `bootstrap-platform`, `bootstrap-github`, `preflight`, and `start` orchestration, including dry-run / execute gating. |
 | `scripts/shiki_tasks.py` | Goal, task, DAG, ledger, lock, worktree-record, repair-packet, and handoff lifecycle helpers. |
+| `scripts/shiki_memory.py` | Memory Loop: capture/promotion state machine with redaction, the ledger-derived scorecard, and deterministic Consult selection of active distilled rules for handoff injection (proposal 0001 v2 §3.1–3.7). |
 | `scripts/shiki_loop.py` | Autonomous post-freeze goal loop: pure decision engine (dispatch / create_pr / rerun_cca / merge / repair / unblock / complete) plus effectors and the `loop step`/`loop run` commands. |
 | `scripts/shiki_runtime.py` | Current daemon, runtime-agnostic runner dispatch (`runner claude` / `runner codex`), smoke, and entrypoint status helpers. |
 | `scripts/shiki_runtime_adapters.py` | Runner adapter boundary: per-runtime tool/auth probes and headless execution commands bound to registry runtime names (ADR 0008). |

--- a/scripts/shiki_loop.py
+++ b/scripts/shiki_loop.py
@@ -311,9 +311,9 @@ def _unblock_ready_tasks(target: Path, goal_id: str) -> list[str]:
             continue
         if worktree_record(target, task["id"]) is None:
             allocate_worktree_record(target, task["id"])
-        handoff = shiki_path(target, "handoffs", f"{task['id']}-task.md")
-        if not handoff.exists():
-            write_task_handoff(target, task["id"])
+        # Regenerate unconditionally: the handoff embeds the live Distilled
+        # Rules section, so a stale cached handoff must never be reused (§3.7).
+        write_task_handoff(target, task["id"])
         unblocked.append(task["id"])
     return unblocked
 
@@ -321,7 +321,10 @@ def _unblock_ready_tasks(target: Path, goal_id: str) -> list[str]:
 def _dispatch(target: Path, task: dict[str, Any], *, repair_id: str | None = None) -> int:
     runtime = str(task.get("assigned_runtime", "claude-code"))
     adapter = get_runner_adapter(runtime)
-    if not repair_id and not shiki_path(target, "handoffs", f"{task['id']}-task.md").exists():
+    # Dispatch always regenerates the task handoff so injected distilled rules are
+    # never stale (§3.7 — the write-if-missing cache is removed). Repair dispatch
+    # uses its own repair handoff and is left untouched.
+    if not repair_id:
         write_task_handoff(target, task["id"])
     args = argparse.Namespace(
         target=str(target),

--- a/scripts/shiki_memory.py
+++ b/scripts/shiki_memory.py
@@ -352,6 +352,125 @@ def load_memory(target: Path, memory_id: str) -> dict[str, Any]:
     return read_json(_memory_path(target, memory_id))
 
 
+def load_all_memories(target: Path) -> list[dict[str, Any]]:
+    """Read every memory entry from .shiki/memories (pure; never mutates)."""
+    mem_dir = shiki_path(target, "memories")
+    if not mem_dir.exists():
+        return []
+    return [read_json(path) for path in sorted(mem_dir.glob("MEM-*.json"))]
+
+
+# --- Consult: deterministic distilled-rule selection (proposal 0001 v2 §3.5) ---
+#
+# CI-08 assumption (operator-approved): the frozen spec selects rules on
+# task.area / goal.area / applies_to / tags, but neither the task nor goal schema
+# defines area/tags and no record carries them. Rather than amend those schemas,
+# T3 derives a non-persisted "consult context" from existing task/goal metadata:
+# task locks (path -> area) and required_skills (-> tags). A distilled rule is
+# selected when it is active/non-revoked/non-superseded, carries at least one
+# selector (area/applies_to/tags), and any selector OR-overlaps the derived
+# context. Reading never mutates state.
+
+# Substring (in a lock path, lowercased) -> coarse MEMORY_AREAS value. Order is
+# irrelevant: every match is unioned into a set, so the derivation is stable.
+_LOCK_AREA_SUBSTRINGS: tuple[tuple[str, str], ...] = (
+    ("mergegate", "mergegate"),
+    ("shiki_loop", "loop"),
+    ("shiki_runtime", "runner"),
+    ("runner", "runner"),
+    ("shiki_memory", "memory"),
+    ("shiki_contracts", "contracts"),
+    ("shiki_migrations", "migrations"),
+    ("validate_shiki", "validator"),
+    ("shiki_tasks", "planning"),
+    ("handoff", "handoff"),
+    ("locks", "locks"),
+    ("cca", "cca"),
+    ("manifest", "manifest"),
+    ("docs/", "docs"),
+    ("context.md", "docs"),
+    ("claude.md", "docs"),
+)
+
+
+def derive_consult_context(task: dict[str, Any], goal: dict[str, Any] | None) -> dict[str, set]:
+    """Derive the non-persisted consult context (areas, tags) for a task/goal.
+
+    Areas come from the task's lock paths; tags come from task and goal
+    required_skills (lowercased). Identifiers/titles are descriptive only and
+    are never used as match input.
+    """
+    areas: set[str] = set()
+    for lock in task.get("locks") or []:
+        path = str(lock).lower()
+        for needle, area in _LOCK_AREA_SUBSTRINGS:
+            if needle in path:
+                areas.add(area)
+    tags: set[str] = set()
+    for skill in (task.get("required_skills") or []):
+        tags.add(str(skill).strip().lower())
+    for skill in ((goal or {}).get("required_skills") or []):
+        tags.add(str(skill).strip().lower())
+    return {"areas": areas, "tags": tags}
+
+
+def _rule_is_eligible(memory: dict[str, Any]) -> bool:
+    """Active, non-revoked, non-superseded distilled rule with >=1 selector."""
+    if memory.get("status") != "distilled":
+        return False
+    if memory.get("active") is not True:
+        return False
+    if memory.get("superseded_by") is not None:
+        return False
+    if memory.get("revoked_at") is not None:
+        return False
+    has_selector = bool(memory.get("area") or memory.get("applies_to") or memory.get("tags"))
+    return has_selector
+
+
+def select_distilled_rules(
+    task: dict[str, Any],
+    goal: dict[str, Any] | None,
+    memories: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Pure, deterministic selection of distilled rules for a handoff.
+
+    Returns active/non-revoked/non-superseded distilled rules whose area /
+    applies_to (matched against the derived areas) or tags (matched against the
+    derived tags) OR-overlap the consult context, stable-sorted by last_verified
+    descending then MEM id ascending (entries missing last_verified sort last).
+    Never mutates ``memories`` or any input.
+    """
+    context = derive_consult_context(task, goal)
+    ctx_areas, ctx_tags = context["areas"], context["tags"]
+    matched: list[dict[str, Any]] = []
+    for memory in memories:
+        if not _rule_is_eligible(memory):
+            continue
+        rule_areas = {memory["area"]} if memory.get("area") else set()
+        rule_areas |= {str(a) for a in (memory.get("applies_to") or [])}
+        rule_tags = {str(t) for t in (memory.get("tags") or [])}
+        if (rule_areas & ctx_areas) or (rule_tags & ctx_tags):
+            matched.append(memory)
+    # Stable sort: id ascending first, then last_verified descending. Python's
+    # sort is stable, so equal last_verified keeps id-ascending order; an empty
+    # last_verified is the smallest key, so reverse=True places it last.
+    matched = sorted(matched, key=lambda m: str(m.get("id") or ""))
+    matched = sorted(matched, key=lambda m: str(m.get("last_verified") or ""), reverse=True)
+    return matched
+
+
+def render_distilled_rules_section(rules: list[dict[str, Any]]) -> list[str]:
+    """Render the always-present ``## Distilled Rules`` handoff section."""
+    lines = ["## Distilled Rules", ""]
+    if not rules:
+        lines.append("none applicable")
+        return lines
+    for rule in rules:
+        lines.append(f"- {str(rule.get('rule', '')).strip()} ({rule.get('id')})")
+    return lines
+
+
 def _save(target: Path, memory: dict[str, Any]) -> None:
     write_json(_memory_path(target, memory["id"]), memory)
 

--- a/scripts/shiki_memory.py
+++ b/scripts/shiki_memory.py
@@ -447,9 +447,12 @@ def select_distilled_rules(
     for memory in memories:
         if not _rule_is_eligible(memory):
             continue
-        rule_areas = {memory["area"]} if memory.get("area") else set()
-        rule_areas |= {str(a) for a in (memory.get("applies_to") or [])}
-        rule_tags = {str(t) for t in (memory.get("tags") or [])}
+        # Normalize rule selectors symmetrically with the derived context
+        # (which is lowercased/stripped) so a case-variant area/applies_to/tag
+        # is never silently dropped.
+        rule_areas = {str(memory["area"]).strip().lower()} if memory.get("area") else set()
+        rule_areas |= {str(a).strip().lower() for a in (memory.get("applies_to") or [])}
+        rule_tags = {str(t).strip().lower() for t in (memory.get("tags") or [])}
         if (rule_areas & ctx_areas) or (rule_tags & ctx_tags):
             matched.append(memory)
     # Stable sort: id ascending first, then last_verified descending. Python's

--- a/scripts/shiki_tasks.py
+++ b/scripts/shiki_tasks.py
@@ -896,7 +896,10 @@ def write_task_handoff(target: Path, task_id: str) -> tuple[Path, str]:
     # applicable" so handoff generation can never break dispatch.
     try:
         goal = load_goal(target, task["goal_id"])
-    except (OSError, ValueError, KeyError):
+    except Exception:
+        # A missing/desynced goal mirror (read_json raises ShikiError) must
+        # degrade to "none applicable", never crash the now-unconditional
+        # dispatch regeneration.
         goal = None
     try:
         distilled = select_distilled_rules(task, goal, load_all_memories(target))

--- a/scripts/shiki_tasks.py
+++ b/scripts/shiki_tasks.py
@@ -882,7 +882,26 @@ def write_handoff(target: Path, name: str, body: str) -> Path:
 
 
 def write_task_handoff(target: Path, task_id: str) -> tuple[Path, str]:
+    # Lazy import keeps the shiki_tasks <-> shiki_memory edge deferred (shiki_memory
+    # imports shiki_tasks at module load), matching the capture/scorecard hooks.
+    from shiki_memory import (
+        load_all_memories,
+        render_distilled_rules_section,
+        select_distilled_rules,
+    )
+
     task = load_task(target, task_id)
+    # Consult injection (proposal 0001 v2 §3.5): always emit a Distilled Rules
+    # section. Selection is failure-tolerant — any read error degrades to "none
+    # applicable" so handoff generation can never break dispatch.
+    try:
+        goal = load_goal(target, task["goal_id"])
+    except (OSError, ValueError, KeyError):
+        goal = None
+    try:
+        distilled = select_distilled_rules(task, goal, load_all_memories(target))
+    except Exception:
+        distilled = []
     body = "\n".join(
         [
             f"# Codex Task Handoff: {task['id']}",
@@ -903,6 +922,8 @@ def write_task_handoff(target: Path, task_id: str) -> tuple[Path, str]:
             "",
             "## Required Skills",
             *[f"- {skill}" for skill in task.get("required_skills", [])],
+            "",
+            *render_distilled_rules_section(distilled),
         ]
     )
     handoff_file = write_handoff(target, f"{task['id']}-task.md", body + "\n")

--- a/tests/test_handoff_consult.py
+++ b/tests/test_handoff_consult.py
@@ -81,6 +81,35 @@ class HandoffConsultTests(unittest.TestCase):
             body = write_task_handoff(root, TASK_ID)[0].read_text(encoding="utf-8")
             self.assertIn("none applicable", body)
 
+    def test_missing_goal_degrades_to_none_applicable(self):
+        # A desynced mirror (goal file absent) must degrade, never crash the
+        # now-unconditional dispatch regeneration.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _seed(root, locks=["path:scripts/shiki_memory.py"])
+            (root / ".shiki" / "goals" / f"{GOAL_ID}.json").unlink()
+            handoff_file, _ = write_task_handoff(root, TASK_ID)  # must not raise
+            body = handoff_file.read_text(encoding="utf-8")
+            self.assertIn("## Distilled Rules", body)
+            self.assertIn("none applicable", body)
+
+    def test_writer_overwrites_stale_handoff(self):
+        # The write-if-missing cache is removed: regenerating always overwrites a
+        # stale on-disk handoff with the freshly injected section.
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _seed(root, locks=["path:scripts/shiki_memory.py"])
+            handoff_path = root / ".shiki" / "handoffs" / f"{TASK_ID}-task.md"
+            handoff_path.parent.mkdir(parents=True, exist_ok=True)
+            handoff_path.write_text("STALE — no distilled rules here\n", encoding="utf-8")
+            _write_rule(root, "MEM-20260612T143733349559Z-fe72ae6a",
+                        area="memory", rule="Declare ledger self-references")
+            write_task_handoff(root, TASK_ID)
+            body = handoff_path.read_text(encoding="utf-8")
+            self.assertNotIn("STALE", body)
+            self.assertIn("## Distilled Rules", body)
+            self.assertIn("(MEM-20260612T143733349559Z-fe72ae6a)", body)
+
     def test_regenerates_and_does_not_mutate_state(self):
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)

--- a/tests/test_handoff_consult.py
+++ b/tests/test_handoff_consult.py
@@ -1,0 +1,105 @@
+"""write_task_handoff always emits a Distilled Rules section (proposal §3.5/§3.7).
+
+The handoff writer injects the selected active distilled rules (with MEM ids) and
+always renders the "## Distilled Rules" heading — "none applicable" when nothing
+matches. Generation is failure-tolerant and never mutates memory/task/goal state;
+dispatch regenerates it every time (no write-if-missing cache).
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from shiki_test_support import synthetic_secrets  # noqa: F401  (path bootstrap)
+
+from shiki_process import ensure_control_dirs
+from shiki_tasks import write_task_handoff
+
+GOAL_ID = "G-20260612T152357704854Z-8a5508cf"
+TASK_ID = "T-20260612T152357707653Z-e200274d"
+
+
+def _seed(root: Path, *, locks, skills=("tdd", "code-review")):
+    ensure_control_dirs(root)
+    (root / ".shiki" / "goals" / f"{GOAL_ID}.json").write_text(
+        json.dumps({"id": GOAL_ID, "status": "planned", "title": "Memory Loop",
+                    "outcome": "o", "required_skills": []}),
+        encoding="utf-8")
+    (root / ".shiki" / "tasks" / f"{TASK_ID}.json").write_text(
+        json.dumps({"id": TASK_ID, "goal_id": GOAL_ID, "status": "ready",
+                    "assigned_runtime": "claude-code", "expected_branch": "b",
+                    "scope": "s", "acceptance_checks": [], "locks": list(locks),
+                    "required_skills": list(skills)}),
+        encoding="utf-8")
+
+
+def _write_rule(root: Path, mem_id, *, area="memory", applies_to=None, tags=None,
+                rule="Declare ledger self-references", active=True,
+                superseded_by=None, revoked_at=None,
+                last_verified="2026-06-10T00:00:00+00:00"):
+    mem_dir = root / ".shiki" / "memories"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    entry = {"id": mem_id, "schema_version": 1, "status": "distilled", "area": area,
+             "applies_to": applies_to or [], "tags": tags or [], "rule": rule,
+             "active": active, "superseded_by": superseded_by, "revoked_at": revoked_at,
+             "last_verified": last_verified, "approved_by": "op", "approved_at": "x"}
+    (mem_dir / f"{mem_id}.json").write_text(json.dumps(entry), encoding="utf-8")
+
+
+class HandoffConsultTests(unittest.TestCase):
+    def test_section_present_none_applicable(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _seed(root, locks=["path:scripts/shiki_memory.py"])
+            handoff_file, _ = write_task_handoff(root, TASK_ID)
+            body = handoff_file.read_text(encoding="utf-8")
+            self.assertIn("## Distilled Rules", body)
+            self.assertIn("none applicable", body)
+
+    def test_matching_rule_injected_with_mem_id(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _seed(root, locks=["path:scripts/shiki_memory.py"])
+            _write_rule(root, "MEM-20260612T143733349559Z-fe72ae6a",
+                        area="memory", rule="Declare ledger self-references")
+            handoff_file, _ = write_task_handoff(root, TASK_ID)
+            body = handoff_file.read_text(encoding="utf-8")
+            self.assertIn("## Distilled Rules", body)
+            self.assertIn("Declare ledger self-references", body)
+            self.assertIn("(MEM-20260612T143733349559Z-fe72ae6a)", body)
+            self.assertNotIn("none applicable", body)
+
+    def test_revoked_rule_never_injected(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _seed(root, locks=["path:scripts/shiki_memory.py"])
+            _write_rule(root, "MEM-20260612T143733349559Z-fe72ae6a",
+                        area="memory", active=False, revoked_at="2026-06-11T00:00:00+00:00")
+            body = write_task_handoff(root, TASK_ID)[0].read_text(encoding="utf-8")
+            self.assertIn("none applicable", body)
+
+    def test_regenerates_and_does_not_mutate_state(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            _seed(root, locks=["path:scripts/shiki_memory.py"])
+            mem_id = "MEM-20260612T143733349559Z-fe72ae6a"
+            _write_rule(root, mem_id, area="memory")
+            mem_path = root / ".shiki" / "memories" / f"{mem_id}.json"
+            task_path = root / ".shiki" / "tasks" / f"{TASK_ID}.json"
+            goal_path = root / ".shiki" / "goals" / f"{GOAL_ID}.json"
+            before = {p: p.read_text(encoding="utf-8") for p in (mem_path, task_path, goal_path)}
+            handoff_file, _ = write_task_handoff(root, TASK_ID)
+            first = handoff_file.read_text(encoding="utf-8")
+            # Regenerate: writer always rewrites (no cache); content is stable.
+            write_task_handoff(root, TASK_ID)
+            self.assertEqual(handoff_file.read_text(encoding="utf-8"), first)
+            for p, original in before.items():
+                self.assertEqual(p.read_text(encoding="utf-8"), original,
+                                 f"consult injection must not mutate {p.name}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_consult.py
+++ b/tests/test_memory_consult.py
@@ -1,0 +1,198 @@
+"""Consult — deterministic distilled-rule injection (proposal 0001 v2 section 3.5).
+
+T3 injects only active, non-superseded, non-revoked distilled rules into the
+handoff, selected deterministically and stable-sorted (last_verified desc, id
+asc), each printed with its MEM id. Because the frozen spec references
+task.area / goal.area but neither the task nor goal schema defines area/tags
+(CI-08 assumption, operator-approved), those operands are a DERIVED,
+non-persisted consult context computed from the task locks (path->area) and
+required_skills (->tags). No schema change; reading never mutates state; when no
+rule matches the handoff still emits "## Distilled Rules" with "none applicable".
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from shiki_test_support import synthetic_secrets  # noqa: F401  (path bootstrap)
+
+from shiki_memory import (
+    derive_consult_context,
+    load_all_memories,
+    render_distilled_rules_section,
+    select_distilled_rules,
+)
+from shiki_process import ensure_control_dirs
+
+GOAL_ID = "G-20260612T152357704854Z-8a5508cf"
+
+
+def _task(locks=None, skills=None, task_id="T-20260612T152357707653Z-e200274d"):
+    return {
+        "id": task_id,
+        "goal_id": GOAL_ID,
+        "locks": locks if locks is not None else ["path:scripts/shiki_memory.py"],
+        "required_skills": skills if skills is not None else ["tdd", "code-review"],
+        "scope": "s",
+        "assigned_runtime": "claude-code",
+        "expected_branch": "b",
+        "acceptance_checks": [],
+    }
+
+
+def _goal(skills=None):
+    return {"id": GOAL_ID, "status": "planned", "title": "Memory Loop",
+            "outcome": "o", "required_skills": skills or []}
+
+
+def _rule(mem_id, *, area="memory", applies_to=None, tags=None, active=True,
+          superseded_by=None, revoked_at=None, last_verified="2026-06-10T00:00:00+00:00",
+          rule="Always declare ledger self-references", status="distilled"):
+    return {
+        "id": mem_id,
+        "schema_version": 1,
+        "status": status,
+        "area": area,
+        "applies_to": applies_to if applies_to is not None else [],
+        "tags": tags if tags is not None else [],
+        "rule": rule,
+        "active": active,
+        "superseded_by": superseded_by,
+        "revoked_at": revoked_at,
+        "last_verified": last_verified,
+        "approved_by": "mizutani-140",
+        "approved_at": "2026-06-10T00:00:00+00:00",
+    }
+
+
+class DeriveConsultContextTests(unittest.TestCase):
+    def test_locks_map_to_areas_and_skills_to_tags(self):
+        ctx = derive_consult_context(
+            _task(locks=["path:scripts/shiki_memory.py", "path:scripts/mergegate_check.py"],
+                  skills=["tdd", "code-review"]),
+            _goal(),
+        )
+        self.assertIn("memory", ctx["areas"])
+        self.assertIn("mergegate", ctx["areas"])
+        self.assertIn("tdd", ctx["tags"])
+        self.assertIn("code-review", ctx["tags"])
+
+    def test_goal_skills_contribute_tags(self):
+        ctx = derive_consult_context(_task(skills=[]), _goal(skills=["diagnose"]))
+        self.assertIn("diagnose", ctx["tags"])
+
+
+class SelectDistilledRulesTests(unittest.TestCase):
+    def test_match_by_area(self):
+        # task locks -> derived area "memory"; rule.area == "memory"
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/shiki_memory.py"]), _goal(),
+            [_rule("MEM-0001", area="memory", applies_to=[], tags=[])],
+        )
+        self.assertEqual([r["id"] for r in rules], ["MEM-0001"])
+
+    def test_match_by_applies_to(self):
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/mergegate_check.py"]), _goal(),
+            [_rule("MEM-0002", area="other", applies_to=["mergegate"], tags=[])],
+        )
+        self.assertEqual([r["id"] for r in rules], ["MEM-0002"])
+
+    def test_match_by_tags(self):
+        rules = select_distilled_rules(
+            _task(locks=["path:docs/x.md"], skills=["tdd"]), _goal(),
+            [_rule("MEM-0003", area="other", applies_to=[], tags=["tdd"])],
+        )
+        self.assertEqual([r["id"] for r in rules], ["MEM-0003"])
+
+    def test_none_applicable_when_no_overlap(self):
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/shiki_memory.py"], skills=["tdd"]), _goal(),
+            [_rule("MEM-0004", area="runner", applies_to=["loop"], tags=["perf"])],
+        )
+        self.assertEqual(rules, [])
+
+    def test_exclude_inactive_revoked_superseded(self):
+        mems = [
+            _rule("MEM-0010", area="memory", active=False),
+            _rule("MEM-0011", area="memory", active=False,
+                  revoked_at="2026-06-11T00:00:00+00:00"),
+            _rule("MEM-0012", area="memory", superseded_by="MEM-0099"),
+            _rule("MEM-0013", area="memory", status="verified"),  # not distilled
+            _rule("MEM-0014", area="memory"),  # the only valid match
+        ]
+        rules = select_distilled_rules(_task(locks=["path:scripts/shiki_memory.py"]), _goal(), mems)
+        self.assertEqual([r["id"] for r in rules], ["MEM-0014"])
+
+    def test_exclude_unscoped_rule(self):
+        # active distilled rule with no overlapping selector is excluded
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/shiki_memory.py"]), _goal(),
+            [_rule("MEM-0020", area="cca", applies_to=[], tags=[])],
+        )
+        self.assertEqual(rules, [])
+
+    def test_stable_sort_last_verified_desc_then_id_asc(self):
+        mems = [
+            _rule("MEM-b", area="memory", last_verified="2026-06-01T00:00:00+00:00"),
+            _rule("MEM-a", area="memory", last_verified="2026-06-09T00:00:00+00:00"),
+            _rule("MEM-c", area="memory", last_verified="2026-06-09T00:00:00+00:00"),
+            _rule("MEM-d", area="memory", last_verified=None),  # missing -> last
+        ]
+        rules = select_distilled_rules(_task(locks=["path:scripts/shiki_memory.py"]), _goal(), mems)
+        self.assertEqual([r["id"] for r in rules], ["MEM-a", "MEM-c", "MEM-b", "MEM-d"])
+
+    def test_selector_does_not_mutate_inputs(self):
+        mems = [_rule("MEM-0030", area="memory")]
+        before = json.dumps(mems, sort_keys=True)
+        select_distilled_rules(_task(locks=["path:scripts/shiki_memory.py"]), _goal(), mems)
+        self.assertEqual(json.dumps(mems, sort_keys=True), before)
+
+
+class RenderSectionTests(unittest.TestCase):
+    def test_none_applicable_section(self):
+        lines = render_distilled_rules_section([])
+        self.assertIn("## Distilled Rules", lines)
+        self.assertIn("none applicable", lines)
+
+    def test_rules_render_with_mem_ids(self):
+        lines = render_distilled_rules_section(
+            [_rule("MEM-0001", rule="Declare ledger self-references")]
+        )
+        text = "\n".join(lines)
+        self.assertIn("## Distilled Rules", text)
+        self.assertIn("Declare ledger self-references", text)
+        self.assertIn("(MEM-0001)", text)
+        self.assertNotIn("none applicable", text)
+
+
+class NoSchemaChangeTests(unittest.TestCase):
+    def test_task_and_goal_schemas_have_no_area_or_tags(self):
+        root = Path(__file__).resolve().parents[1]
+        for name in ("task.schema.json", "goal.schema.json"):
+            schema = json.loads((root / ".shiki" / "schemas" / name).read_text(encoding="utf-8"))
+            props = schema.get("properties", {})
+            self.assertNotIn("area", props, f"{name} must not gain an area field (CI-08 assumption)")
+            self.assertNotIn("tags", props, f"{name} must not gain a tags field (CI-08 assumption)")
+
+
+class LoadAllMemoriesTests(unittest.TestCase):
+    def test_reads_without_mutation(self):
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            ensure_control_dirs(root)
+            mem_dir = root / ".shiki" / "memories"
+            mem_dir.mkdir(parents=True, exist_ok=True)
+            entry = _rule("MEM-20260615T000000000000Z-aaaaaaaa", area="memory")
+            (mem_dir / f"{entry['id']}.json").write_text(json.dumps(entry), encoding="utf-8")
+            before = (mem_dir / f"{entry['id']}.json").read_text(encoding="utf-8")
+            loaded = load_all_memories(root)
+            self.assertEqual([m["id"] for m in loaded], [entry["id"]])
+            self.assertEqual((mem_dir / f"{entry['id']}.json").read_text(encoding="utf-8"), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_memory_consult.py
+++ b/tests/test_memory_consult.py
@@ -127,23 +127,52 @@ class SelectDistilledRulesTests(unittest.TestCase):
         rules = select_distilled_rules(_task(locks=["path:scripts/shiki_memory.py"]), _goal(), mems)
         self.assertEqual([r["id"] for r in rules], ["MEM-0014"])
 
-    def test_exclude_unscoped_rule(self):
-        # active distilled rule with no overlapping selector is excluded
+    def test_exclude_no_overlap_rule(self):
+        # active distilled rule whose selectors do not overlap is excluded
         rules = select_distilled_rules(
             _task(locks=["path:scripts/shiki_memory.py"]), _goal(),
             [_rule("MEM-0020", area="cca", applies_to=[], tags=[])],
         )
         self.assertEqual(rules, [])
 
+    def test_exclude_revoked_alone(self):
+        # revoked_at set must exclude on its own, independent of the active flag
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/shiki_memory.py"]), _goal(),
+            [_rule("MEM-0021", area="memory", active=True,
+                   revoked_at="2026-06-11T00:00:00+00:00")],
+        )
+        self.assertEqual(rules, [])
+
+    def test_exclude_zero_selector_rule(self):
+        # a rule with NO selectors (area/applies_to/tags all empty) never matches,
+        # even against a context that would otherwise overlap.
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/shiki_memory.py"]), _goal(),
+            [_rule("MEM-0022", area="", applies_to=[], tags=[])],
+        )
+        self.assertEqual(rules, [])
+
     def test_stable_sort_last_verified_desc_then_id_asc(self):
+        # The tied pair (same last_verified) is fed in id-DESCENDING order so the
+        # assertion can only hold if the selector actively re-sorts by id asc on
+        # the tie (stable sort alone would keep MEM-c before MEM-a).
         mems = [
             _rule("MEM-b", area="memory", last_verified="2026-06-01T00:00:00+00:00"),
-            _rule("MEM-a", area="memory", last_verified="2026-06-09T00:00:00+00:00"),
             _rule("MEM-c", area="memory", last_verified="2026-06-09T00:00:00+00:00"),
+            _rule("MEM-a", area="memory", last_verified="2026-06-09T00:00:00+00:00"),
             _rule("MEM-d", area="memory", last_verified=None),  # missing -> last
         ]
         rules = select_distilled_rules(_task(locks=["path:scripts/shiki_memory.py"]), _goal(), mems)
         self.assertEqual([r["id"] for r in rules], ["MEM-a", "MEM-c", "MEM-b", "MEM-d"])
+
+    def test_match_is_case_insensitive(self):
+        # case-variant applies_to/tags must still match the normalized context
+        rules = select_distilled_rules(
+            _task(locks=["path:scripts/shiki_memory.py"], skills=["TDD"]), _goal(),
+            [_rule("MEM-0023", area="Memory", applies_to=["MEMORY"], tags=["Tdd"])],
+        )
+        self.assertEqual([r["id"] for r in rules], ["MEM-0023"])
 
     def test_selector_does_not_mutate_inputs(self):
         mems = [_rule("MEM-0030", area="memory")]


### PR DESCRIPTION
## Shiki
Task: T-20260612T152357707653Z-e200274d
Goal: G-20260612T152357704854Z-8a5508cf (Memory Loop)
CCA checklist profile: PR, TDD, V, CCA
Risk: high

## Scope
Implement proposal 0001 v2 §3.5 (Consult) and §3.7 (dispatch regen + docs) on top of T1/T2:
- `select_distilled_rules` / `derive_consult_context` / `render_distilled_rules_section` in `scripts/shiki_memory.py` — pure, deterministic selection of active, non-revoked, non-superseded distilled rules (≥1 selector, OR-overlap, stable-sort `last_verified` desc / MEM id asc), each printed with its MEM id.
- `write_task_handoff` (`scripts/shiki_tasks.py`) always emits a `## Distilled Rules` section ("none applicable" when empty), failure-tolerant, no state mutation.
- Dispatch regenerates the handoff every time — write-if-missing cache removed in `scripts/shiki_loop.py` (`_dispatch` + `_unblock_ready_tasks`); the `shiki_runtime.py` safety guard is kept.
- Docs: H-12 (`docs/agents/checklists.md`, section-presence-only, blocking when applicable), CONTEXT.md glossary (Memory, Distilled Rule, Scorecard), session-start reading (CLAUDE.md, `.claude/commands/shiki.md`, source-of-truth blocks untouched), new `docs/agents/memory.md`, CLI architecture module row.

## Non-goals
- No task/goal schema change (CI-08 assumption below). No CCA prompt change. No capture change (T2).
- No T1/T2 state change, no DAG change, no goal-complete (T3 → `review`, not `done`; goal stays active while T3 is the only non-done task).

## Acceptance
- Active distilled rules are injected with MEM ids in deterministic order; revoked/superseded/inactive/unscoped are never injected; "none applicable" when no rule matches (tests prove all).
- Handoffs regenerate on every dispatch; H-12 present (section-presence-only); session-start reads documented; glossary entries added.
- `validate_shiki.py` + the full contract suite pass; no schema change (a test asserts task/goal schemas gain no `area`/`tags`).

## Context & Impact (CI-08) and Assumption Log
Context & Impact was produced by a 5-agent Workflow exploration sweep. It surfaced one genuine spec-vs-code conflict: §3.5 selects rules on `task.area`/`goal.area`, but neither the task nor goal schema defines `area`/`tags` and no record carries them. **Operator-approved resolution (Assumption Log, NOT a Spec Amendment):** `task.area`/`goal.area` are implemented as a **derived, non-persisted consult context** computed from existing task lock paths (→ areas) and `required_skills` (→ tags). A rule matches when it is active/non-revoked/non-superseded, has ≥1 selector (`area`/`applies_to`/`tags`), and any selector OR-overlaps the derived context. No `area`/`tags` field is added to task or goal records; the plan `spec_freeze.amendments` stays empty. Today (zero active distilled rules) the executed path is always "none applicable". Recorded in ledger `L-…89172cca` (type `context-impact`).

## Evidence
- python3 scripts/validate_shiki.py
- python3 -m unittest discover -s tests  (217 tests)
- scripts/test_shiki_*.sh  (32 shell contract tests)

## TDD
Red-green-refactor: failing tests written first in `tests/test_memory_consult.py` (17) and `tests/test_handoff_consult.py` (6) covering deterministic injection, MEM ids, revoked/superseded/inactive/zero-selector exclusion, none-applicable, stable sort, case-insensitive match, no-mutation, no-schema-change, missing-goal degradation, and cache-removal regeneration; then minimal implementation. Ledger `L-…c9a43f50`.

## Pre-PR code review
The `code-review` skill ran as a 5-dimension adversarial multi-agent review (selector correctness, handoff/cache, acceptance/tests, safety, docs/scope) against `main...e150ca6`. It found **1 blocking** (missing-goal crash — `ShikiError` escaped the goal-load guard in `write_task_handoff`, which is now called unconditionally), **3 major** (stable-sort tiebreak unproven; revoked-alone exclusion unproven; the failure-tolerance gap), and minors (symmetric selector normalization; a doc symbol; extra tests). **All fixed and regression-tested; 0 confirmed findings remain.** Ledger `L-…5f942ca1`.

## MergeGate
High-risk control-plane + implementation change. Merges only with an independent Guardian authority (external AI guardian review artifact, ADR 0010, head-SHA bound) or the human guardian path. All other MergeGate/CCA blockers pre-cleared: dependency T1 done, files within T3 locks, self-reference ledger, `expected_branch`==head, required_skills (tdd, code-review) in ledger evidence, `cca_checklist_profile` present, this `## Pre-PR code review` section. CCA-08 is intended to be the sole remaining blocker.
