### PR TITLE
T-20260617T020914950053Z-592052d8: Add slugify unit tests

### DIFF
--- a/.shiki/goals/G-20260617T020914948443Z-6f29448f.json
+++ b/.shiki/goals/G-20260617T020914948443Z-6f29448f.json
@@ -1,0 +1,26 @@
+{
+  "id": "G-20260617T020914948443Z-6f29448f",
+  "github_issue": null,
+  "title": "Add slugify unit tests",
+  "outcome": "The pure helper slugify(value) in scripts/shiki_process.py is characterized by a unittest suite in tests/test_slugify.py, covering its observable behavior without any production code change.",
+  "completion_conditions": [
+    "tests/test_slugify.py exists and asserts slugify('Hello, World!')=='hello-world', non-alphanumeric runs collapse to a single '-', leading/trailing separators are stripped, empty/all-symbol input returns 'task', and the result is truncated to at most 48 characters.",
+    "python3 -m unittest discover -s tests passes.",
+    "python3 scripts/validate_shiki.py passes."
+  ],
+  "non_goals": [
+    "No production code change.",
+    "No change to any file outside tests/."
+  ],
+  "risk_level": "low",
+  "required_skills": [
+    "tdd"
+  ],
+  "acceptance_evidence": [
+    "python3 -m unittest discover -s tests output showing tests/test_slugify.py passing.",
+    "python3 scripts/validate_shiki.py passing.",
+    "GitHub PR #139 required checks green."
+  ],
+  "status": "ready",
+  "created_at": "2026-06-17T02:09:14+00:00"
+}

--- a/.shiki/ledger/L-20260617T021950746394Z-c6050121.json
+++ b/.shiki/ledger/L-20260617T021950746394Z-c6050121.json
@@ -1,0 +1,15 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    "https://github.com/mizutani-140/shiki/pull/139"
+  ],
+  "goal_id": "G-20260617T020914948443Z-6f29448f",
+  "id": "L-20260617T021950746394Z-c6050121",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/139"
+  ],
+  "summary": "GitHub PR #139 created for T-20260617T020914950053Z-592052d8",
+  "task_id": "T-20260617T020914950053Z-592052d8",
+  "timestamp": "2026-06-17T02:19:50+00:00",
+  "type": "handoff"
+}

--- a/.shiki/tasks/T-20260617T020914950053Z-592052d8.json
+++ b/.shiki/tasks/T-20260617T020914950053Z-592052d8.json
@@ -1,0 +1,35 @@
+{
+  "acceptance_checks": [
+    "tests/test_slugify.py exists and asserts slugify('Hello, World!')=='hello-world', empty/all-symbol input -> 'task', non-alphanumeric runs collapse to one '-', and the 48-character cap.",
+    "python3 -m unittest discover -s tests passes.",
+    "python3 scripts/validate_shiki.py passes."
+  ],
+  "assigned_runtime": "claude-code",
+  "dependencies": [],
+  "expected_branch": "shiki/t-20260617t020914950053z-592052d8-add-slugify-unit-tests",
+  "expected_pr": 139,
+  "github_issue": null,
+  "goal_id": "G-20260617T020914948443Z-6f29448f",
+  "id": "T-20260617T020914950053Z-592052d8",
+  "ledger_evidence": [
+    "L-20260617T020914950171Z-36422459",
+    "L-20260617T020914953397Z-28dd133d",
+    "L-20260617T020914954531Z-e76875f9",
+    "L-20260617T021201021557Z-78c8426d",
+    "L-20260617T021950746394Z-c6050121"
+  ],
+  "locks": [
+    "path:tests/*"
+  ],
+  "non_goals": [
+    "No production code change.",
+    "No change to any file outside tests/."
+  ],
+  "required_skills": [
+    "tdd"
+  ],
+  "risk_level": "low",
+  "scope": "Add a new test file tests/test_slugify.py with unittest cases covering the existing pure helper slugify(value) in scripts/shiki_process.py. Cover: slugify('Hello, World!') == 'hello-world'; runs of non-alphanumeric characters collapse to a single '-'; leading/trailing separators are stripped; empty or all-symbol input returns 'task'; the result is truncated to at most 48 characters. Do not modify any production code; add only the test file.",
+  "status": "review",
+  "title": "Add slugify unit tests"
+}

--- a/.shiki/tasks/T-20260617T020914950053Z-592052d8.json
+++ b/.shiki/tasks/T-20260617T020914950053Z-592052d8.json
@@ -19,6 +19,7 @@
     "L-20260617T021950746394Z-c6050121"
   ],
   "locks": [
+    "path:.shiki/**",
     "path:tests/*"
   ],
   "non_goals": [

--- a/.shiki/worktrees/T-20260617T020914950053Z-592052d8.json
+++ b/.shiki/worktrees/T-20260617T020914950053Z-592052d8.json
@@ -1,0 +1,14 @@
+{
+  "branch": "shiki/t-20260617t020914950053z-592052d8-add-slugify-unit-tests",
+  "created_at": "2026-06-17T02:09:14+00:00",
+  "created_by": "shiki-run",
+  "goal_id": "G-20260617T020914948443Z-6f29448f",
+  "locks": [
+    "path:tests/*"
+  ],
+  "path": "/Users/kio.mizutani/.worktrees/shiki-t-20260617t020914950053z-592052d8-add-slug",
+  "pr": 139,
+  "runtime": "claude-code",
+  "state": "active",
+  "task_id": "T-20260617T020914950053Z-592052d8"
+}

--- a/tests/test_slugify.py
+++ b/tests/test_slugify.py
@@ -1,0 +1,58 @@
+"""T-20260617T020914950053Z-592052d8 — unit tests for the pure ``slugify`` helper.
+
+These characterize the observable behavior of ``scripts/shiki_process.slugify``:
+lowercasing, collapsing runs of non-alphanumeric characters to a single ``-``,
+stripping leading/trailing separators, falling back to ``"task"`` for empty or
+all-symbol input, and capping the result at 48 characters. They import the real
+module and never modify it.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import shiki_test_support  # noqa: F401  (path bootstrap)
+
+from shiki_process import slugify
+
+
+class SlugifyTests(unittest.TestCase):
+    def test_basic_punctuation_and_case(self) -> None:
+        self.assertEqual(slugify("Hello, World!"), "hello-world")
+
+    def test_lowercases_input(self) -> None:
+        self.assertEqual(slugify("FooBar"), "foobar")
+
+    def test_collapses_runs_of_non_alphanumeric(self) -> None:
+        for value in ("foo   bar", "foo___bar", "foo!!!@@@bar", "foo - bar"):
+            result = slugify(value)
+            self.assertEqual(result, "foo-bar", f"unexpected slug for {value!r}")
+            self.assertNotIn("--", result)
+
+    def test_strips_leading_and_trailing_separators(self) -> None:
+        for value in ("  hello  ", "---hello---", "!hello!", "...hello..."):
+            self.assertEqual(slugify(value), "hello", f"unexpected slug for {value!r}")
+
+    def test_empty_input_returns_task(self) -> None:
+        self.assertEqual(slugify(""), "task")
+
+    def test_all_symbol_input_returns_task(self) -> None:
+        for value in ("!!!", "@#$%", "   ", "---", "...,,,"):
+            self.assertEqual(slugify(value), "task", f"unexpected slug for {value!r}")
+
+    def test_truncates_to_48_characters(self) -> None:
+        result = slugify("a" * 60)
+        self.assertEqual(len(result), 48)
+        self.assertEqual(result, "a" * 48)
+
+    def test_long_mixed_input_capped_at_48_characters(self) -> None:
+        value = "The quick brown fox jumps over the lazy dog again and again"
+        result = slugify(value)
+        self.assertLessEqual(len(result), 48)
+
+    def test_short_input_not_truncated(self) -> None:
+        self.assertEqual(slugify("short-slug"), "short-slug")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Shiki
Goal: G-20260617T020914948443Z-6f29448f
Task: T-20260617T020914950053Z-592052d8
CCA checklist profile: PR, TDD, V, CCA

## Scope
Add a new test file tests/test_slugify.py with unittest cases covering the existing pure helper slugify(value) in scripts/shiki_process.py. Cover: slugify('Hello, World!') == 'hello-world'; runs of non-alphanumeric characters collapse to a single '-'; leading/trailing separators are stripped; empty or all-symbol input returns 'task'; the result is truncated to at most 48 characters. Do not modify any production code; add only the test file.

## Non-goals
- No production code change.
- No change to any file outside tests/.

## Acceptance
- tests/test_slugify.py exists and asserts slugify('Hello, World!')=='hello-world', empty/all-symbol input -> 'task', non-alphanumeric runs collapse to one '-', and the 48-character cap.
- python3 -m unittest discover -s tests passes.
- python3 scripts/validate_shiki.py passes.

## Evidence
- python3 scripts/validate_shiki.py

## Ledger evidence
- L-20260617T020914950171Z-36422459
- L-20260617T020914953397Z-28dd133d
- L-20260617T020914954531Z-e76875f9
- L-20260617T021201021557Z-78c8426d

## MergeGate
- Locks: path:tests/*
- Risk: low
- CCA required: yes