### PR TITLE
#140 T1 closeout: mark done + release lock (unblocks T2-T5)

### DIFF
--- a/.shiki/ledger/L-20260617T104239318215Z-2c16606c.json
+++ b/.shiki/ledger/L-20260617T104239318215Z-2c16606c.json
@@ -1,0 +1,15 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/tasks/T-20260617T031753971551Z-24f8c42f.json"
+  ],
+  "goal_id": "G-20260617T031753970001Z-1de3b322",
+  "id": "L-20260617T104239318215Z-2c16606c",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/144"
+  ],
+  "summary": "T1 closeout: branch plumbing merged in PR #141; mark T1 done and release its lock so the sibling slices T2-T5 (which share .shiki/**, shiki_loop.py, tests/* locks) can land. Self-references PR #144. T2-T5 remain planned/review so the goal stays active (DAG-based).",
+  "task_id": "T-20260617T031753971551Z-24f8c42f",
+  "timestamp": "2026-06-17T10:42:39.318215+00:00",
+  "type": "check"
+}

--- a/.shiki/locks/T-20260617T031753971551Z-24f8c42f.json
+++ b/.shiki/locks/T-20260617T031753971551Z-24f8c42f.json
@@ -10,6 +10,6 @@
     "path:tests/*"
   ],
   "owner": "shiki-run",
-  "state": "active",
+  "state": "released",
   "task_id": "T-20260617T031753971551Z-24f8c42f"
 }

--- a/.shiki/tasks/T-20260617T031753971551Z-24f8c42f.json
+++ b/.shiki/tasks/T-20260617T031753971551Z-24f8c42f.json
@@ -12,8 +12,8 @@
     "CCA"
   ],
   "dependencies": [],
-  "expected_branch": "shiki/t1-loop-branch-plumbing",
-  "expected_pr": 141,
+  "expected_branch": "shiki/t1-closeout",
+  "expected_pr": 144,
   "github_issue": null,
   "goal_id": "G-20260617T031753970001Z-1de3b322",
   "id": "T-20260617T031753971551Z-24f8c42f",
@@ -24,7 +24,8 @@
     "L-20260617T031753976357Z-05c002c1",
     "L-20260617T034222726208Z-95e3c688",
     "L-20260617T034222728376Z-4f3f7e65",
-    "L-20260617T034222728493Z-23f42f48"
+    "L-20260617T034222728493Z-23f42f48",
+    "L-20260617T104239318215Z-2c16606c"
   ],
   "locks": [
     "path:.shiki/**",
@@ -45,6 +46,6 @@
   ],
   "risk_level": "high",
   "scope": "Land the implementer's work and complete evidence on the task branch before create_pr (gaps #1/#2). Add a loop-owned commit+push-implementation step after a green dispatch (commit the worktree source changes; git push -u origin <expected_branch>). Rewrite _sync_state_to_branch (scripts/shiki_loop.py) to copy EVERY file referenced by the reloaded task.ledger_evidence (each .shiki/ledger/<id>.json plus every .shiki-relative path in that ledger's evidence list, e.g. .shiki/runner/EXEC-*, .shiki/reports/R-*) into the worktree, then add/commit/push; reorder so the branch is pushable before create_github_pr_for_task (scripts/shiki_github.py:293). Deterministic, fail-closed, loop-owned.",
-  "status": "review",
+  "status": "done",
   "title": "Branch plumbing: commit+push implementation + full ledger-evidence sync"
 }


### PR DESCRIPTION
## Shiki
Task: T-20260617T031753971551Z-24f8c42f
Goal: G-20260617T031753970001Z-1de3b322 (#140)
CCA checklist profile: PR, TDD, V, CCA
Risk: high

## Scope
Closeout of **T1 (Branch plumbing)** — implementation merged in PR #141. Mark T1 `done` and **release its lock**. T1's lock held `.shiki/**`, `scripts/shiki_loop.py`, `scripts/shiki_github.py`, `scripts/test_shiki_*.sh`, `tests/*` — all shared with T2–T5, so its active lock blocked every sibling slice's MergeGate. Releasing it unblocks the T2–T5 landings.
- T1 `status` → `done`; lock `state` → `released`; T1-scoped closeout ledger.

## Non-goals
- No code change. No T2–T5 change. No goal-complete (T2–T5 remain planned/review, so the goal stays active by the DAG-based rule).

## Acceptance
- T1 is `done`, its lock is `released`; only the T1 task file + lock + a T1-scoped ledger change. `validate_shiki.py` passes and does NOT force goal-complete.

## Evidence
- python3 scripts/validate_shiki.py

## Pre-PR code review
Not applicable — control-plane-only closeout (no implementation code; only T1's task/lock state + a ledger). T1's implementation code-review evidence is in PR #141. Recorded here as the PR-12 N/A justification.

## MergeGate
High-risk closeout. Lock release is under T1's own task id (no self-conflict). Merges only with a Guardian authority (external AI guardian, ADR 0010) or the human path. CCA-08 intended as the sole blocker.
