### PR TITLE
Gap A closeout (#140 T5): task done + release lock + goal complete

### DIFF
--- a/.shiki/goals/G-20260618T044709324112Z-bc9365c6.json
+++ b/.shiki/goals/G-20260618T044709324112Z-bc9365c6.json
@@ -8,6 +8,9 @@
   "created_at": "2026-06-18T04:47:09+00:00",
   "github_issue": 140,
   "id": "G-20260618T044709324112Z-bc9365c6",
+  "ledger_evidence": [
+    "L-20260618T050611540032Z-0c1a7fe9"
+  ],
   "non_goals": [
     "No change to the loop's completion semantics (Gap B / pushing goal-complete to main is separate).",
     "No multi-task DAG sync (guarded off to avoid validate_dag node-mismatch)."
@@ -19,6 +22,6 @@
     "code-review"
   ],
   "risk_level": "medium",
-  "status": "planned",
+  "status": "complete",
   "title": "Repair: loop must sync goal/dag/lock to the task branch (Gap A; #140 T5 self-drive)"
 }

--- a/.shiki/ledger/L-20260618T050611429383Z-b17861d5.json
+++ b/.shiki/ledger/L-20260618T050611429383Z-b17861d5.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/tasks/T-20260618T044720078664Z-7502dbd0.json"
+  ],
+  "goal_id": "G-20260618T044709324112Z-bc9365c6",
+  "id": "L-20260618T050611429383Z-b17861d5",
+  "links": [],
+  "summary": "Task T-20260618T044720078664Z-7502dbd0 status changed to done",
+  "task_id": "T-20260618T044720078664Z-7502dbd0",
+  "timestamp": "2026-06-18T05:06:11+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260618T050611540032Z-0c1a7fe9.json
+++ b/.shiki/ledger/L-20260618T050611540032Z-0c1a7fe9.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/reports/R-20260618T050611531481Z-ea52af70.json"
+  ],
+  "goal_id": "G-20260618T044709324112Z-bc9365c6",
+  "id": "L-20260618T050611540032Z-0c1a7fe9",
+  "links": [],
+  "summary": "Gap A (sync goal/dag/lock to the task branch) implemented and merged in PR #151; the loop's task PR is now self-contained for a locally-started goal. Unblocks Gap B + the #140 T5 live self-drive.",
+  "task_id": null,
+  "timestamp": "2026-06-18T05:06:11+00:00",
+  "type": "completion"
+}

--- a/.shiki/ledger/L-20260618T050710119057Z-5b05cb77.json
+++ b/.shiki/ledger/L-20260618T050710119057Z-5b05cb77.json
@@ -1,0 +1,16 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/locks/T-20260618T044720078664Z-7502dbd0.json",
+    ".shiki/tasks/T-20260618T044720078664Z-7502dbd0.json"
+  ],
+  "goal_id": "G-20260618T044709324112Z-bc9365c6",
+  "id": "L-20260618T050710119057Z-5b05cb77",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/152"
+  ],
+  "summary": "Closeout reconcile in PR #152 (/pull/152): Gap A task marked done, lock released (state=released), single-task goal completed with scorecard. Impl shipped in PR #151. Frees scripts/shiki_loop.py for Gap B.",
+  "task_id": "T-20260618T044720078664Z-7502dbd0",
+  "timestamp": "2026-06-18T05:07:10+00:00",
+  "type": "lock"
+}

--- a/.shiki/locks/T-20260618T044720078664Z-7502dbd0.json
+++ b/.shiki/locks/T-20260618T044720078664Z-7502dbd0.json
@@ -14,9 +14,12 @@
     "path:.shiki/ledger/L-20260618T045513327225Z-41b85411.json",
     "path:.shiki/ledger/L-20260618T045513327354Z-85f8a408.json",
     "path:.shiki/ledger/L-20260618T045513327444Z-58814daa.json",
-    "path:.shiki/ledger/L-20260618T045627360645Z-bb765a78.json"
+    "path:.shiki/ledger/L-20260618T045627360645Z-bb765a78.json",
+    "path:.shiki/ledger/L-20260618T050611429383Z-b17861d5.json",
+    "path:.shiki/ledger/L-20260618T050611540032Z-0c1a7fe9.json",
+    "path:.shiki/reports/R-20260618T050611531481Z-ea52af70.json"
   ],
   "owner": "claude-code",
-  "state": "active",
+  "state": "released",
   "task_id": "T-20260618T044720078664Z-7502dbd0"
 }

--- a/.shiki/locks/T-20260618T044720078664Z-7502dbd0.json
+++ b/.shiki/locks/T-20260618T044720078664Z-7502dbd0.json
@@ -17,7 +17,8 @@
     "path:.shiki/ledger/L-20260618T045627360645Z-bb765a78.json",
     "path:.shiki/ledger/L-20260618T050611429383Z-b17861d5.json",
     "path:.shiki/ledger/L-20260618T050611540032Z-0c1a7fe9.json",
-    "path:.shiki/reports/R-20260618T050611531481Z-ea52af70.json"
+    "path:.shiki/reports/R-20260618T050611531481Z-ea52af70.json",
+    "path:.shiki/ledger/L-20260618T050710119057Z-5b05cb77.json"
   ],
   "owner": "claude-code",
   "state": "released",

--- a/.shiki/reports/R-20260618T050611531481Z-ea52af70.json
+++ b/.shiki/reports/R-20260618T050611531481Z-ea52af70.json
@@ -1,0 +1,51 @@
+{
+  "blocking_reasons": [],
+  "created_at": "2026-06-18T05:06:11+00:00",
+  "evidence": [
+    ".shiki/tasks/T-20260618T044720078664Z-7502dbd0.json"
+  ],
+  "goal_id": "G-20260618T044709324112Z-bc9365c6",
+  "id": "R-20260618T050611531481Z-ea52af70",
+  "mergegate": {
+    "checks": "pass",
+    "dependencies": "pass",
+    "ledger": "pass",
+    "locks": "pass",
+    "review": "recorded",
+    "risk": "medium"
+  },
+  "scorecard": {
+    "cca_reruns": {
+      "total": 0
+    },
+    "duration_ms": 1142000,
+    "generated_at": "2026-06-18T05:06:11+00:00",
+    "goal_id": "G-20260618T044709324112Z-bc9365c6",
+    "lock_amendments": {
+      "total": 0
+    },
+    "loop_stops": {
+      "by_reason": {},
+      "total": 0
+    },
+    "repairs": {
+      "by_area": {},
+      "total": 0
+    },
+    "suggestions": [],
+    "tasks": {
+      "completed": 1,
+      "failed": 0,
+      "total": 1
+    },
+    "warnings": [
+      "loop_stops are captured as raw memories and are not counted by the ledger-only scorecard"
+    ],
+    "window": {
+      "from": "2026-06-18T04:47:09+00:00",
+      "to": "2026-06-18T05:06:11+00:00"
+    }
+  },
+  "status": "complete",
+  "summary": "Gap A (sync goal/dag/lock to the task branch) implemented and merged in PR #151; the loop's task PR is now self-contained for a locally-started goal. Unblocks Gap B + the #140 T5 live self-drive."
+}

--- a/.shiki/tasks/T-20260618T044720078664Z-7502dbd0.json
+++ b/.shiki/tasks/T-20260618T044720078664Z-7502dbd0.json
@@ -6,7 +6,7 @@
   ],
   "assigned_runtime": "claude-code",
   "dependencies": [],
-  "expected_branch": "shiki/t-20260618t044720078664z-7502dbd0-sync-goal-guarded-dag-lock-to-the-task-branch-in",
+  "expected_branch": "shiki/t-7502dbd0-closeout",
   "expected_pr": 151,
   "github_issue": null,
   "goal_id": "G-20260618T044709324112Z-bc9365c6",
@@ -18,7 +18,9 @@
     "L-20260618T045513327225Z-41b85411",
     "L-20260618T045513327354Z-85f8a408",
     "L-20260618T045513327444Z-58814daa",
-    "L-20260618T045627360645Z-bb765a78"
+    "L-20260618T045627360645Z-bb765a78",
+    "L-20260618T050611429383Z-b17861d5",
+    "L-20260618T050611540032Z-0c1a7fe9"
   ],
   "locks": [
     "path:scripts/shiki_loop.py",
@@ -33,7 +35,10 @@
     "path:.shiki/ledger/L-20260618T045513327225Z-41b85411.json",
     "path:.shiki/ledger/L-20260618T045513327354Z-85f8a408.json",
     "path:.shiki/ledger/L-20260618T045513327444Z-58814daa.json",
-    "path:.shiki/ledger/L-20260618T045627360645Z-bb765a78.json"
+    "path:.shiki/ledger/L-20260618T045627360645Z-bb765a78.json",
+    "path:.shiki/ledger/L-20260618T050611429383Z-b17861d5.json",
+    "path:.shiki/ledger/L-20260618T050611540032Z-0c1a7fe9.json",
+    "path:.shiki/reports/R-20260618T050611531481Z-ea52af70.json"
   ],
   "non_goals": [
     "No change to loop completion semantics (Gap B is separate).",
@@ -46,7 +51,7 @@
   ],
   "risk_level": "medium",
   "scope": "In _evidence_relatives_for_task (scripts/shiki_loop.py), add .shiki/goals/<goal_id>.json and .shiki/locks/<task_id>.json to the synced set, and .shiki/dag/<goal_id>.json only when the DAG's node set is a subset of {this task_id} (single-task safety; multi-task DAG sync would trip validate_dag). add()'s is_file guard no-ops on missing files. Add EvidenceRelatives tests.",
-  "status": "review",
+  "status": "done",
   "test_command": "python3 -m unittest discover -s tests",
   "title": "Sync goal + guarded dag + lock to the task branch in _evidence_relatives_for_task"
 }

--- a/.shiki/tasks/T-20260618T044720078664Z-7502dbd0.json
+++ b/.shiki/tasks/T-20260618T044720078664Z-7502dbd0.json
@@ -7,7 +7,7 @@
   "assigned_runtime": "claude-code",
   "dependencies": [],
   "expected_branch": "shiki/t-7502dbd0-closeout",
-  "expected_pr": 151,
+  "expected_pr": 152,
   "github_issue": null,
   "goal_id": "G-20260618T044709324112Z-bc9365c6",
   "id": "T-20260618T044720078664Z-7502dbd0",
@@ -20,7 +20,8 @@
     "L-20260618T045513327444Z-58814daa",
     "L-20260618T045627360645Z-bb765a78",
     "L-20260618T050611429383Z-b17861d5",
-    "L-20260618T050611540032Z-0c1a7fe9"
+    "L-20260618T050611540032Z-0c1a7fe9",
+    "L-20260618T050710119057Z-5b05cb77"
   ],
   "locks": [
     "path:scripts/shiki_loop.py",
@@ -38,7 +39,8 @@
     "path:.shiki/ledger/L-20260618T045627360645Z-bb765a78.json",
     "path:.shiki/ledger/L-20260618T050611429383Z-b17861d5.json",
     "path:.shiki/ledger/L-20260618T050611540032Z-0c1a7fe9.json",
-    "path:.shiki/reports/R-20260618T050611531481Z-ea52af70.json"
+    "path:.shiki/reports/R-20260618T050611531481Z-ea52af70.json",
+    "path:.shiki/ledger/L-20260618T050710119057Z-5b05cb77.json"
   ],
   "non_goals": [
     "No change to loop completion semantics (Gap B is separate).",


### PR DESCRIPTION
## Shiki
- Task: `T-20260618T044720078664Z-7502dbd0`
- Goal: `G-20260618T044709324112Z-bc9365c6` — Gap A repair (links #140 T5)
- Risk: **medium**

## Scope
Closeout of the Gap A loop sync fix — **implementation merged in PR #151**. Mark the task `done`, **release its lock** (it holds `scripts/shiki_loop.py`, which Gap B must also modify), and complete the single-task repair goal with the scorecard.
- Task `status`→`done`; lock `state`→`released`; goal `status`→`complete`.

## Non-goals
- No code change (shipped in #151). No other task/goal touched.

## Acceptance
- Task `done`, lock `released`, goal `complete` with scorecard; `validate_shiki` passes (single-task coupling satisfied).

## Evidence
- Impl + green CI: PR #151 (merged) — Validate ✓, MergeGate ✓, CCA ✓.
- Completion report `R-…ea52af70`; completion ledger `L-…0c1a7fe9`; task-done ledger `L-…b17861d5`.

## MergeGate
- Required checks: Validate, MergeGate policy, CCA. Normal closeout (#144/#149 pattern). Risk medium → no Guardian; merge needs operator authorization.
- Lock released in this PR (no active-lock conflict — own-task self-skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
