### PR TITLE
Smoke goal closeout (#140 T5 Gap A): push loop auto-merge completion to main

### DIFF
--- a/.shiki/goals/G-20260618T051732213600Z-07292ac0.json
+++ b/.shiki/goals/G-20260618T051732213600Z-07292ac0.json
@@ -20,7 +20,8 @@
   },
   "id": "G-20260618T051732213600Z-07292ac0",
   "ledger_evidence": [
-    "L-20260618T051732213858Z-9a8192a0"
+    "L-20260618T051732213858Z-9a8192a0",
+    "L-20260618T052728776458Z-9bec9da9"
   ],
   "non_goals": [
     "No production code change (test-only).",
@@ -33,6 +34,6 @@
   ],
   "risk_level": "low",
   "source_plan": "P-20260618T051732212741Z-70648973",
-  "status": "planned",
+  "status": "complete",
   "title": "Live loop self-drive acceptance (low-risk smoke)"
 }

--- a/.shiki/ledger/L-20260618T052728669839Z-c68f0036.json
+++ b/.shiki/ledger/L-20260618T052728669839Z-c68f0036.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/tasks/T-20260618T051732214442Z-bae28ee3.json"
+  ],
+  "goal_id": "G-20260618T051732213600Z-07292ac0",
+  "id": "L-20260618T052728669839Z-c68f0036",
+  "links": [],
+  "summary": "Task T-20260618T051732214442Z-bae28ee3 status changed to done",
+  "task_id": "T-20260618T051732214442Z-bae28ee3",
+  "timestamp": "2026-06-18T05:27:28+00:00",
+  "type": "check"
+}

--- a/.shiki/ledger/L-20260618T052728776458Z-9bec9da9.json
+++ b/.shiki/ledger/L-20260618T052728776458Z-9bec9da9.json
@@ -1,0 +1,13 @@
+{
+  "actor": "shiki-cli",
+  "evidence": [
+    ".shiki/reports/R-20260618T052728767806Z-a4721faf.json"
+  ],
+  "goal_id": "G-20260618T051732213600Z-07292ac0",
+  "id": "L-20260618T052728776458Z-9bec9da9",
+  "links": [],
+  "summary": "Live #140 T5 Gap A validation: the autonomous loop self-drove this smoke task to AUTO-MERGE (PR #153, zero manual intervention). Completion is pushed to main via this closeout (the loop's local goal_complete did not yet push to main \u2014 that is Gap B). tests/test_loop_smoke.py is merged.",
+  "task_id": null,
+  "timestamp": "2026-06-18T05:27:28+00:00",
+  "type": "completion"
+}

--- a/.shiki/ledger/L-20260618T052838950440Z-63e90baf.json
+++ b/.shiki/ledger/L-20260618T052838950440Z-63e90baf.json
@@ -1,0 +1,16 @@
+{
+  "actor": "claude-code",
+  "evidence": [
+    ".shiki/locks/T-20260618T051732214442Z-bae28ee3.json",
+    ".shiki/tasks/T-20260618T051732214442Z-bae28ee3.json"
+  ],
+  "goal_id": "G-20260618T051732213600Z-07292ac0",
+  "id": "L-20260618T052838950440Z-63e90baf",
+  "links": [
+    "https://github.com/mizutani-140/shiki/pull/154"
+  ],
+  "summary": "Closeout reconcile in PR #154 (/pull/154): smoke task done, lock released, goal completed with scorecard. The loop auto-merged the impl in PR #153 (live Gap A self-drive). Frees the tests/* + .shiki/** lock for the Gap B repair.",
+  "task_id": "T-20260618T051732214442Z-bae28ee3",
+  "timestamp": "2026-06-18T05:28:38+00:00",
+  "type": "lock"
+}

--- a/.shiki/locks/T-20260618T051732214442Z-bae28ee3.json
+++ b/.shiki/locks/T-20260618T051732214442Z-bae28ee3.json
@@ -6,6 +6,6 @@
     "path:tests/*"
   ],
   "owner": "shiki-run",
-  "state": "active",
+  "state": "released",
   "task_id": "T-20260618T051732214442Z-bae28ee3"
 }

--- a/.shiki/reports/R-20260618T052728767806Z-a4721faf.json
+++ b/.shiki/reports/R-20260618T052728767806Z-a4721faf.json
@@ -1,0 +1,51 @@
+{
+  "blocking_reasons": [],
+  "created_at": "2026-06-18T05:27:28+00:00",
+  "evidence": [
+    ".shiki/tasks/T-20260618T051732214442Z-bae28ee3.json"
+  ],
+  "goal_id": "G-20260618T051732213600Z-07292ac0",
+  "id": "R-20260618T052728767806Z-a4721faf",
+  "mergegate": {
+    "checks": "pass",
+    "dependencies": "pass",
+    "ledger": "pass",
+    "locks": "pass",
+    "review": "recorded",
+    "risk": "low"
+  },
+  "scorecard": {
+    "cca_reruns": {
+      "total": 0
+    },
+    "duration_ms": 596000,
+    "generated_at": "2026-06-18T05:27:28+00:00",
+    "goal_id": "G-20260618T051732213600Z-07292ac0",
+    "lock_amendments": {
+      "total": 1
+    },
+    "loop_stops": {
+      "by_reason": {},
+      "total": 0
+    },
+    "repairs": {
+      "by_area": {},
+      "total": 0
+    },
+    "suggestions": [],
+    "tasks": {
+      "completed": 1,
+      "failed": 0,
+      "total": 1
+    },
+    "warnings": [
+      "loop_stops are captured as raw memories and are not counted by the ledger-only scorecard"
+    ],
+    "window": {
+      "from": "2026-06-18T05:17:32+00:00",
+      "to": "2026-06-18T05:27:28+00:00"
+    }
+  },
+  "status": "complete",
+  "summary": "Live #140 T5 Gap A validation: the autonomous loop self-drove this smoke task to AUTO-MERGE (PR #153, zero manual intervention). Completion is pushed to main via this closeout (the loop's local goal_complete did not yet push to main \u2014 that is Gap B). tests/test_loop_smoke.py is merged."
+}

--- a/.shiki/tasks/T-20260618T051732214442Z-bae28ee3.json
+++ b/.shiki/tasks/T-20260618T051732214442Z-bae28ee3.json
@@ -6,7 +6,7 @@
   "assigned_runtime": "claude-code",
   "dependencies": [],
   "expected_branch": "shiki/t-bae28ee3-closeout",
-  "expected_pr": 153,
+  "expected_pr": 154,
   "github_issue": null,
   "goal_id": "G-20260618T051732213600Z-07292ac0",
   "id": "T-20260618T051732214442Z-bae28ee3",
@@ -19,7 +19,8 @@
     "L-20260618T051909281082Z-404c4960",
     "L-20260618T051912934221Z-abc16dec",
     "L-20260618T052728669839Z-c68f0036",
-    "L-20260618T052728776458Z-9bec9da9"
+    "L-20260618T052728776458Z-9bec9da9",
+    "L-20260618T052838950440Z-63e90baf"
   ],
   "locks": [
     "path:.shiki/**",

--- a/.shiki/tasks/T-20260618T051732214442Z-bae28ee3.json
+++ b/.shiki/tasks/T-20260618T051732214442Z-bae28ee3.json
@@ -5,7 +5,7 @@
   ],
   "assigned_runtime": "claude-code",
   "dependencies": [],
-  "expected_branch": "shiki/t-20260618t051732214442z-bae28ee3-add-a-trivial-smoke-test",
+  "expected_branch": "shiki/t-bae28ee3-closeout",
   "expected_pr": 153,
   "github_issue": null,
   "goal_id": "G-20260618T051732213600Z-07292ac0",
@@ -17,7 +17,9 @@
     "L-20260618T051836784873Z-cbe4e750",
     "L-20260618T051909235168Z-9ae6af00",
     "L-20260618T051909281082Z-404c4960",
-    "L-20260618T051912934221Z-abc16dec"
+    "L-20260618T051912934221Z-abc16dec",
+    "L-20260618T052728669839Z-c68f0036",
+    "L-20260618T052728776458Z-9bec9da9"
   ],
   "locks": [
     "path:.shiki/**",
@@ -37,7 +39,7 @@
   ],
   "risk_level": "low",
   "scope": "Create tests/test_loop_smoke.py containing exactly one unittest.TestCase with one test method that asserts a trivially-true fact (e.g. self.assertTrue(True)). Do not modify any other file. The file must import cleanly and the test must pass.",
-  "status": "review",
+  "status": "done",
   "test_command": "python3 -m unittest discover -s tests -p test_loop_smoke.py",
   "title": "Add a trivial smoke test"
 }


### PR DESCRIPTION
## Shiki
- Task: `T-20260618T051732214442Z-bae28ee3`
- Goal: `G-20260618T051732213600Z-07292ac0` — live #140 T5 Gap A self-drive validation
- Risk: **low** (test-only smoke goal)

## Scope
Closeout of the smoke goal whose implementation the autonomous loop **auto-merged in PR #153** (zero manual intervention — the live Gap A validation). Push the loop's completion to main: task `done`, lock `released`, goal `complete` (scorecard). The loop computed this locally but does not yet push it to main (Gap B); this is the manual equivalent, and it frees the `tests/*` + `.shiki/**` lock for the Gap B repair.

## Non-goals
- No code change (`tests/test_loop_smoke.py` already merged in #153).

## Acceptance
- Task `done`, lock `released`, goal `complete` with scorecard; `validate_shiki` passes (single-task coupling satisfied).

## Evidence
- Loop self-drive to auto-merge: PR #153 (merged 05:22:48Z) — its CI shows Validate ✓ (Gap A made it pass), CCA ✓, auto-merged by the loop's `merge` action at cycle 11.
- Completion report `R-…a4721faf`; completion ledger `L-…9bec9da9`; task-done ledger `L-…c68f0036`.

## MergeGate
- Required checks: Validate, MergeGate policy, CCA. Normal closeout. Risk low → auto-merge tier; merge needs operator authorization.
- `.shiki/**` lock covers the new closeout files; lock released in this PR (own-task self-skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
